### PR TITLE
Use sass-lint-underdog for SASS linting

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,35 +1,6 @@
-options:
-  formatter: stylish
 files:
   include: 'scss/**/*.scss'
 rules:
-  class-name-format:
-    - 2
-    -
-      # http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/
-      convention: 'hyphenatedbem'
-  # TODO: Move this to an inline rule ignore in `public/icons/_icons-auto.scss` when the feature is landed
-  #   https://github.com/sasstools/sass-lint/pull/402
-  #   https://github.com/sasstools/sass-lint/issues/70
-  final-newline: 0
-
-  # Enforce long form hex notation, e.g. `#FFFFFF` vs `#FFF`
-  hex-length:
-    - 2
-    -
-      style: 'long'
-  # Enforce upper case hex notation, e.g. `#FFFFFF` vs `#ffffff`
-  hex-notation:
-    - 2
-    -
-      style: 'uppercase'
-
-  # Enforce leading-zero, e.g. `0.75` vs `.75`
-  leading-zero:
-    - 2
-    -
-      include: true
-
   # Whitelist selectors which have to show up multiple times
   # DEV: `sass-lint` doesn't count wrapping styles in `@include media-query-custom(small) { ... }`
   #   as a non-mergeable selector
@@ -45,10 +16,3 @@ rules:
     -
       extra-properties:
         - 'osx-font-smoothing'
-
-  # Allow vendor prefixes, e.g. `-webkit-{property}`
-  no-vendor-prefixes: 0
-
-  # Disable check for placeholders in `@extend`
-  #   allow `@extend .cf`, instead of `@extend %cf`
-  placeholder-in-extend: 0

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "build": "npm run clean && node-sass --include-path bower_components/ --output dist/css/ --output-style compressed scss/style.scss && cp -R fonts/ dist/",
     "build-icons": "gulp build-icons",
     "develop": "node-sass --include-path bower_components/ --output dist/css/ --watch scss/ --recursive  scss/style.scss",
+    "lint": "sass-lint-underdog",
     "postinstall": "bower install && npm run build",
-    "test": "sass-lint --config .sass-lint.yml --verbose",
+    "test": "npm run lint",
     "start": "bin/underdog-styles"
   },
   "homepage": "https://github.com/underdogio/underdog-styles",
@@ -24,7 +25,7 @@
     "gulp-notify": "2.2.0",
     "node-sass": "3.4.2",
     "pug": "0.1.0",
-    "sass-lint": "git://github.com/underdogio/sass-lint#56b8ef8",
+    "sass-lint-underdog": "1.2.0",
     "underscore": "1.8.3"
   }
 }


### PR DESCRIPTION
Now that we have `sass-lint-underdog` which wraps our default `sass-lint` config, we should use it in this repo :)

/cc @brettlangdon
