### PR TITLE
Add gemini test suite

### DIFF
--- a/.gemini.yml
+++ b/.gemini.yml
@@ -1,0 +1,11 @@
+# Load from our local browser
+rootUrl: http://localhost:9008
+gridUrl: http://localhost:4444/wd/hub
+
+# Give ourselves a little looser tolerance
+tolerance: 10
+
+browsers:
+  chrome:
+    desiredCapabilities:
+      browserName: firefox

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bower_components/
 dist/
+gemini/
 node_modules/
 npm-debug.log

--- a/bin/underdog-styles
+++ b/bin/underdog-styles
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-var port = process.env.PORT || 3000;
 var App = require('../');
-App.listen(port, function () {
-  console.log('underdog-styles is running at http://localhost:' + port + '/');
+App.listen(9008, function () {
+  console.log('underdog-styles is running at http://localhost:9008/');
 });

--- a/package.json
+++ b/package.json
@@ -8,10 +8,15 @@
     "build": "npm run clean && node-sass --include-path bower_components/ --output dist/css/ --output-style compressed scss/style.scss && cp -R fonts/ dist/",
     "build-icons": "gulp build-icons",
     "develop": "node-sass --include-path bower_components/ --output dist/css/ --watch scss/ --recursive  scss/style.scss",
+    "gemini-gather": "gemini gather test/visual/*.js",
+    "gemini-gui": "gemini-gui test/visual/*.js",
+    "gemini-test": "gemini test --reporter html --reporter flat test/visual/*.js",
     "lint": "sass-lint-underdog",
     "postinstall": "bower install && npm run build",
     "test": "npm run lint",
-    "start": "bin/underdog-styles"
+    "start": "bin/underdog-styles",
+    "start-webdriver": "webdriver-manager start",
+    "webdriver-update": "webdriver-manager update --standalone"
   },
   "homepage": "https://github.com/underdogio/underdog-styles",
   "private": true,
@@ -19,6 +24,8 @@
     "async": "1.5.2",
     "bower": "1.7.7",
     "express": "4.13.4",
+    "gemini": "2.1.1",
+    "gemini-gui": "2.2.1",
     "gulp": "3.9.1",
     "gulp-consolidate": "0.2.0",
     "gulp-iconfont": "6.0.0",
@@ -26,6 +33,7 @@
     "node-sass": "3.4.2",
     "pug": "0.1.0",
     "sass-lint-underdog": "1.2.0",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "webdriver-manager": "8.0.0"
   }
 }

--- a/test/visual/index.js
+++ b/test/visual/index.js
@@ -1,0 +1,59 @@
+// Load in our dependencies
+var gemini = require('gemini');
+
+// Define our URLs to evaluate
+var staticUrls = [
+  // Fetch the UI kit
+  '/'
+];
+
+// Provide a helper to bind new fluent methods
+function addCustomFunctions(suite) {
+  suite.captureExtraLarge = function (fn) {
+    return suite.capture('1920-onload', function setSize1920 (actions, find) {
+      actions.setWindowSize(1920, 1080);
+      if (fn) {
+        fn(actions, find);
+      }
+    });
+  };
+  suite.captureLarge = function (fn) {
+    return suite.capture('1400-onload', function setSize1024 (actions, find) {
+      actions.setWindowSize(1400, 788);
+      if (fn) {
+        fn(actions, find);
+      }
+    });
+  };
+  suite.captureMedium = function (fn) {
+    return suite.capture('768-onload', function setSize640 (actions, find) {
+      actions.setWindowSize(768, 432);
+      if (fn) {
+        fn(actions, find);
+      }
+    });
+  };
+  suite.captureSmall = function (fn) {
+    return suite.capture('530-onload', function setSize320 (actions, find) {
+      actions.setWindowSize(530, 398);
+      if (fn) {
+        fn(actions, find);
+      }
+    });
+  };
+  suite.captureMultipleSizes = function (fn) {
+    return suite.captureExtraLarge(fn).captureLarge(fn).captureMedium(fn).captureSmall(fn);
+  };
+  return suite;
+}
+
+// Define our tests
+// For each of these pages, open it, navigate to it, and screenshot it
+staticUrls.forEach(function captureUrl (url) {
+  gemini.suite('underdog-styles-' + encodeURIComponent(url), function captureMultipleSizes (suite) {
+    addCustomFunctions(suite);
+    suite.setUrl(url)
+      .setCaptureElements('body')
+      .captureMultipleSizes();
+  });
+});


### PR DESCRIPTION
We wanted to add in `gemini` visual testing suite so that we can ensure any major changes we make to these global styles don't mess with anything.

Added here is just `gemini`, and a test suite to check the UI kit at our different breakpoints.

/cc @brettlangdon
