### PR TITLE
Fix line-height issue with nav-link

### DIFF
--- a/scss/objects/_links.scss
+++ b/scss/objects/_links.scss
@@ -5,7 +5,7 @@
 
 // Navigation links (typically found in sidebars/header/etc)
 .nav-link {
-  @extend .gamma;
+  @include font-size($gamma-font-size, false);
   color: $nav-link-color;
   text-decoration: none;
 
@@ -22,7 +22,7 @@
 
 // Menu links (typically found in menus and dropdowns)
 .menu-link {
-  @extend .gamma;
+  @include font-size($gamma-font-size, false);
 
   color: $menu-link-color;
   text-decoration: none;


### PR DESCRIPTION
When working on adding `underdog-styles` to `dogtag`, we noticed something off with the way `line-heights` were being interpreted for `.header__nav`.

This PR aims to fix the issue by utilizing the `font-size($font-size, $line-height : true)` `inuit.css` mixin instead of `@extend .gamma`.

/cc @brettlangdon
