### PR TITLE
Create classes to maintain consistent spacing

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -24,6 +24,7 @@
 @import 'variables/grid';
 @import 'variables/icons';
 @import 'variables/links';
+@import 'variables/section';
 @import 'variables/wrapper';
 
 // Component variables

--- a/scss/objects/_section.scss
+++ b/scss/objects/_section.scss
@@ -1,0 +1,32 @@
+// Helps to maintain vertical rhythm.
+// =======
+// <section class="section">
+//   <div class="section__subsection">
+//       <!-- Some content in here -->
+//   </div>
+//   <div class="section__subsection">
+//       <!-- Some content in here -->
+//   </div>
+// </section>
+// ======
+.section {
+  margin-bottom: $section-spacing;
+}
+
+.section--pad {
+  padding-bottom: $section-spacing;
+  padding-top: $section-spacing;
+}
+
+.section__subsection {
+  margin-bottom: $subsection-spacing;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.section__subsection--pad {
+  padding-bottom: $subsection-spacing;
+  padding-top: $subsection-spacing;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -8,6 +8,7 @@
 @import 'objects/grid';
 @import 'objects/icons';
 @import 'objects/links';
+@import 'objects/section';
 @import 'objects/wrapper';
 
 // Underdog specific components

--- a/scss/variables/_section.scss
+++ b/scss/variables/_section.scss
@@ -1,0 +1,5 @@
+// Section spacing
+$section-spacing: $base-spacing-unit * 4 !default;
+
+// Subsection spacing
+$subsection-spacing: $base-spacing-unit * 2 !default;

--- a/server/views/ui-kit.pug
+++ b/server/views/ui-kit.pug
@@ -59,6 +59,8 @@ html
         li
           a(href="#alerts") Alerts
         li
+          a(href="#sections") Sections
+        li
           a(href="#section-divider") Section divider
         li
           a(href="#sidebar") Sidebar
@@ -578,6 +580,34 @@ html
           = '  <button class="alert__close">\r\n'
           = '    <span class="icon icon-close" aria-label="close" />\r\n'
           = '  </button>\r\n'
+          = '</div>'
+    #sections.section-divider
+      .section-divider__heading Sections
+      .section-divider__links
+        a(href="#toc") Scroll to top
+    .container
+      p Sections help to maintain vertical rhythm.
+      .section.border--bottom.border--left
+        span SECTION
+        .section__subsection.border--bottom.border--left SUBSECTION
+        .section__subsection.border--bottom.border--left SUBSECTION
+      .section.section--pad.border--bottom.border--left
+        span SECTION WITH PADDING
+        .section__subsection.section__subsection--pad.border--bottom.border--left SUBSECTION WITH PADDING
+        span SECTION WITH PADDING CONTINUED
+      pre
+        code
+          = '<div class="section">\r\n'
+          = '  <span>SECTION</span>\r\n'
+          = '  <div class="section__subsection">SUBSECTION</div>\r\n'
+          = '  <div class="section__subsection">SUBSECTION</div>\r\n'
+          = '</div>\r\n'
+          = '<div class="section section--pad">\r\n'
+          = '  <span>SECTION WITH PADDING</span>\r\n'
+          = '  <div class="section__subsection section__subsection--pad">\r\n'
+          = '    SUBSECTION WITH PADDING\r\n'
+          = '  </div>\r\n'
+          = '  <span>SECTION WITH PADDING CONTINUED</span>\r\n'
           = '</div>'
     #section-divider.section-divider
       .section-divider__heading Section divider


### PR DESCRIPTION
This PR adds a few helper classes that are intended to enforce consistent vertical spacing between sections, `section` and `subsection`.

These are just classes with bottom margins applied to them, but having dedicated classes for sections, rather than applying spacing helpers as needed, ensures that vertical spacing stays consistent.

There is also a `--pad` modifier for each of these classes that adds padding to the top and bottom of any element. This is useful for sections that have colored backgrounds. 

/cc @underdogio/engineering 
