### PR TITLE
Create 'wrapper' class for adding padding around elements

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -24,6 +24,7 @@
 @import 'variables/grid';
 @import 'variables/icons';
 @import 'variables/links';
+@import 'variables/wrapper';
 
 // Component variables
 @import 'variables/header';

--- a/scss/objects/_wrapper.scss
+++ b/scss/objects/_wrapper.scss
@@ -1,0 +1,11 @@
+.wrapper {
+  @include media-query-medium {
+    padding: $wrapper-medium-padding;
+  }
+
+  @include media-query-large-and-up {
+    padding: $wrapper-large-and-up-padding;
+  }
+
+  padding: $wrapper-padding;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -8,6 +8,7 @@
 @import 'objects/grid';
 @import 'objects/icons';
 @import 'objects/links';
+@import 'objects/wrapper';
 
 // Underdog specific components
 @import 'components/header';

--- a/scss/variables/_wrapper.scss
+++ b/scss/variables/_wrapper.scss
@@ -1,0 +1,3 @@
+$wrapper-padding: $gutter-width !default;
+$wrapper-medium-padding: $wrapper-padding * 3 !default;
+$wrapper-large-and-up-padding: $wrapper-padding * 6 !default;


### PR DESCRIPTION
This PR adds a `wrapper` class to help maintain consistent spacing.

Creating a class that just adds padding may seem silly, but having a dedicated class, rather than relying on helper classes with arbitrary values, will help to enforce consistent spacing.

/cc @underdogio/engineering 
