### PR TITLE
Reset base list styling

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -10,3 +10,4 @@
 @import 'base/headings';
 @import 'base/forms';
 @import 'base/links';
+@import 'base/lists';

--- a/scss/base/_lists.scss
+++ b/scss/base/_lists.scss
@@ -1,0 +1,10 @@
+ul,
+ol {
+  list-style-type: none;
+  margin: 0;
+}
+
+.list--bullet {
+  list-style-type: disc;
+  margin-left: $gutter-width;
+}


### PR DESCRIPTION
In almost every case when using a list element (like for navigation, dropdowns, etc.), you don't want the default styling.

For those other cases, there is the `.list--bullet` class.

If we'd rather keep the default list styling, we could create a mixin instead and include that as needed.

/cc @underdogio/engineering 
