### PR TITLE
Fix fonts output directory on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/",
   "scripts": {
     "clean": "rm -rf dist/",
-    "build": "npm run clean && node-sass --include-path bower_components/ --output dist/css/ --output-style compressed scss/underdog.scss && cp -R fonts/ dist/",
+    "build": "npm run clean && node-sass --include-path bower_components/ --output dist/css/ --output-style compressed scss/underdog.scss && cp -R fonts/ dist/fonts/",
     "build-icons": "gulp build-icons",
     "develop": "node-sass --include-path bower_components/ --output dist/css/ --watch scss/ --recursive  scss/underdog.scss",
     "gemini-gather": "gemini gather test/visual/*.js",


### PR DESCRIPTION
Fonts were being outputted to `dist` instead of `dist/fonts`. No more.

/cc @underdogio/engineering 
