### PR TITLE
Menu drawer component

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -30,5 +30,8 @@
 
 // Component variables
 @import 'variables/header';
+@import 'variables/list-heading';
+@import 'variables/menu-drawer';
+@import 'variables/menu-list';
 @import 'variables/section-divider';
 @import 'variables/sidebar';

--- a/scss/components/_list-heading.scss
+++ b/scss/components/_list-heading.scss
@@ -1,0 +1,9 @@
+// Heading for a list.
+// <span class="list-heading">Menu title</span>
+// <ul>...</ul>
+.list-heading {
+  color: $list-heading-color;
+  display: block;
+  font-weight: 500;
+  padding: $list-heading-padding;
+}

--- a/scss/components/_menu-drawer.scss
+++ b/scss/components/_menu-drawer.scss
@@ -1,0 +1,58 @@
+// A menu drawer, for having a sidebar menu overlay.
+// <div class="menu-drawer">
+//   <div class="menu-drawer__content">
+//     <span class="menu-drawer__close icon-btn__ic icon icon-close" role="button" aria-label="menu close"></span>
+//     <div class="menu-drawer__section">
+//         <!-- Menu content -->
+//     </div>
+//   </div>
+// </div>
+.menu-drawer {
+  @include transition(background);
+
+  height: 100%;
+  pointer-events: none;
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 100%;
+
+  &.is-active {
+    background: $menu-drawer-overlay-bg;
+    pointer-events: auto;
+
+    .menu-drawer__content {
+      transform: translateX(0);
+    }
+  }
+}
+
+.menu-drawer__content {
+  @include transition(transform);
+
+  background: $menu-drawer-content-bg;
+  height: 100%;
+  max-width: $menu-drawer-max-width;
+  overflow-y: auto;
+  padding-top: $base-spacing-unit * 2; // Add some room for the close icon
+  position: absolute;
+  right: 0;
+  transform: translateX(100%);
+  width: $menu-drawer-width;
+}
+
+.menu-drawer__close {
+  position: absolute;
+  right: $base-spacing-unit;
+  top: $base-spacing-unit;
+}
+
+.menu-drawer__section {
+  border-top: $menu-drawer-section-border;
+  margin-bottom: $menu-drawer-section-spacing;
+  padding: $menu-drawer-section-padding;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/scss/components/_menu-list.scss
+++ b/scss/components/_menu-list.scss
@@ -1,0 +1,8 @@
+.menu-list__item {
+  display: block;
+  margin-bottom: $menu-list-item-spacing;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -13,6 +13,9 @@
 
 // Underdog specific components
 @import 'components/header';
+@import 'components/list-heading';
+@import 'components/menu-drawer';
+@import 'components/menu-list';
 @import 'components/section-divider';
 @import 'components/sidebar';
 

--- a/scss/variables/_list-heading.scss
+++ b/scss/variables/_list-heading.scss
@@ -1,0 +1,2 @@
+$list-heading-color: $dark-gray !default;
+$list-heading-padding: $base-spacing-width !default;

--- a/scss/variables/_menu-drawer.scss
+++ b/scss/variables/_menu-drawer.scss
@@ -1,0 +1,7 @@
+$menu-drawer-width: 480px !default;
+$menu-drawer-max-width: 95% !default;
+$menu-drawer-section-padding:  $base-spacing-unit $base-spacing-width !default;
+$menu-drawer-section-spacing: $base-spacing-unit !default;
+$menu-drawer-overlay-bg: rgba($black, 0.5) !default;
+$menu-drawer-content-bg: $gray-xf3;
+$menu-drawer-section-border: 1px solid $gray-xdc;

--- a/scss/variables/_menu-list.scss
+++ b/scss/variables/_menu-list.scss
@@ -1,0 +1,1 @@
+$menu-list-item-spacing: $base-spacing-unit !default;

--- a/server/docs/menu-drawer.md
+++ b/server/docs/menu-drawer.md
@@ -1,0 +1,96 @@
+---
+title: Menu Drawer
+---
+
+A hidden drawer that can be toggled by the user. Can be toggled by adding or removing the `.is-active` class.
+The content within the menu drawer is scrollable.
+
+<div class="menu-drawer is-active" style="position: relative; height: 360px;">
+  <div class="menu-drawer__content">
+    <span class="menu-drawer__close icon-btn__ic icon icon-close" role="button" aria-label="menu close"></span>
+    <span class="list-heading">Settings</span>
+    <div class="menu-drawer__section">
+      <ul class="menu-list">
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Profile</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Notifications</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Billing</a>
+        </li>
+      </ul>
+    </div>
+    <span class="list-heading">Batch</span>
+    <div class="menu-drawer__section">
+      <ul class="menu-list">
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Profile</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Notifications</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Billing</a>
+        </li>
+      </ul>
+    </div>
+    <div class="menu-drawer__section">
+      <ul class="menu-list">
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Support</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Sign Out</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="menu-drawer is-active">
+  <div class="menu-drawer__content">
+    <span class="menu-drawer__close icon-btn__ic icon icon-close" role="button" aria-label="menu close"></span>
+    <span class="list-heading">Settings</span>
+    <div class="menu-drawer__section">
+      <ul class="menu-list">
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Profile</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Notifications</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Billing</a>
+        </li>
+      </ul>
+    </div>
+    <span class="list-heading">Batch</span>
+    <div class="menu-drawer__section">
+      <ul class="menu-list">
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Profile</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Notifications</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Billing</a>
+        </li>
+      </ul>
+    </div>
+    <div class="menu-drawer__section">
+      <ul class="menu-list">
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Support</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="#">Sign Out</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+```


### PR DESCRIPTION
Adds a `menu-drawer` component, which can be used for hiding a navigational menu in narrow viewports.

The `menu-drawer` can be toggled by adding or removing an `.is-active` class.

FYI: In an actual app the menu-drawer would be fixed to take up the entire screen, but for the styleguide I added an inline style so that the drawer would be contained within a single section. I also restricted the drawer's height to demonstrate that it could be scrolled independently of the body.

Including a screenshot, but I recommend that you test the component in your browser. Be sure to toggle the `is-active` class so you can see what the transition animation looks like:

![screencapture-localhost-9008-1458524884184](https://cloud.githubusercontent.com/assets/6979137/13909284/535a7c78-eee6-11e5-9367-3722007610a8.png)

/cc @underdogio/engineering 
