### PR TITLE
Add variable for horizontal spacing unit

### DIFF
--- a/scss/variables/_grid.scss
+++ b/scss/variables/_grid.scss
@@ -1,4 +1,7 @@
+// Horizontal spacing
+$base-spacing-width: 14px !default;
+
 // Grid
 $columns: 12;
-$gutter-width: 14px;
+$gutter-width: $base-spacing-width !default;
 $row-max-width: 1400px;


### PR DESCRIPTION
Adds a variable `$base-spacing-width` for base horizontal spacing unit. Also sets the grid gutter to this variable.

/cc @underdogio/engineering 
