### PR TITLE
Upgrade sass-lint-underdog

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-notify": "2.2.0",
     "meta-marked": "0.4.0",
     "node-sass": "3.4.2",
-    "sass-lint-underdog": "1.2.0",
+    "sass-lint-underdog": "1.3.0",
     "slug": "0.9.1",
     "underscore": "1.8.3",
     "webdriver-manager": "8.0.0"


### PR DESCRIPTION
We noticed an issue with `sass-lint-underdog` not failing on warnings, so we have update `sass-lint-underdog` to support this. Now we just need to update here.

/cc @underdogio/engineering 
