### PR TITLE
Add npm start-develop script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ cd ./underdog-styles
 # Install dependencies
 npm install
 
-# Start development server
+# Start server
 npm start
+
+# Start server and restart on changes from server/
+npm run start-develop
 
 # Start `node-sass` watching for changes in scss/
 npm run develop

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postinstall": "bower install && npm run build",
     "test": "npm run lint",
     "start": "bin/underdog-styles",
+    "start-develop": "nodemon --exec bin/underdog-styles --watch server/ --ext js,md,hbs",
     "start-webdriver": "webdriver-manager start",
     "webdriver-update": "webdriver-manager update --standalone"
   },
@@ -34,6 +35,7 @@
     "gulp-notify": "2.2.0",
     "meta-marked": "0.4.0",
     "node-sass": "3.4.2",
+    "nodemon": "1.9.1",
     "sass-lint-underdog": "1.3.0",
     "slug": "0.9.1",
     "underscore": "1.8.3",


### PR DESCRIPTION
When developing locally it is nice to have a development server that will auto-restart on changes. For example, when modifying anything in `server/docs/` it would be nice if you didn't have to manually refresh the server to see the changes. So in this PR we are adding in `nodemon` which we will run via `npm run start-develop` to run our server and restart on any changes to `server/`.

/cc @underdogio/engineering 
