### PR TITLE
Add horizontal line divider

### DIFF
--- a/scss/objects/_divider.scss
+++ b/scss/objects/_divider.scss
@@ -1,0 +1,38 @@
+// Vertically centered horizontal line with optional text
+//
+// <div class="divider">
+//   <spanclass="divider__text">
+//     text
+//   </span>
+// </div>
+//
+// Inspired from the login form at https://www.firebase.com/login/
+
+// Variables
+$divider-color: $gray-xdc !default;
+$divider-height: 1px !default;
+$divider-text-bg: $white !default;
+
+.divider {
+  margin-bottom: 1em;
+  position: relative;
+  text-align: center;
+
+  &:before {
+    border-top: solid $divider-height $divider-color;
+    bottom: 0;
+    content: '';
+    left: 1em;
+    margin: 0;
+    position: absolute;
+    right: 1em;
+    top: 50%;
+    z-index: -1;
+  }
+}
+
+.divider__text {
+  background: $divider-text-bg;
+  padding-left: 1em;
+  padding-right: 1em;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -5,6 +5,7 @@
 @import 'objects/alerts';
 @import 'objects/buttons';
 @import 'objects/container';
+@import 'objects/divider';
 @import 'objects/grid';
 @import 'objects/icons';
 @import 'objects/links';

--- a/server/docs/divider.md
+++ b/server/docs/divider.md
@@ -1,0 +1,24 @@
+---
+title: Divider
+---
+You can utilize a `.divider` if you need a vertically centered horizontal rule which may contain text.
+
+<div class="row">
+  <div class="col-6-large-and-up col-12-medium-and-down">
+    <div class="divider"></div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-6-large-and-up col-12-medium-and-down">
+    <div class="divider">
+      <span class="divider__text">text</span>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="divider">
+  <!-- .divider__text is optional -->
+  <span class="divider__text">text</span>
+</div>
+```


### PR DESCRIPTION
We have been needing a horizontal line with text to help break up the forms on `dogtag`. We have been struggling with figuring out how to do this... until now.

![image](https://cloud.githubusercontent.com/assets/1320353/14254627/975742e8-fa5e-11e5-81fe-c4459a378847.png)

/cc @underdogio/engineering 
