### PR TITLE
Define common push helpers

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -16,6 +16,7 @@
 @import 'variables/colors';
 @import 'variables/borders';
 @import 'variables/media-queries';
+@import 'variables/push';
 @import 'variables/transitions';
 
 // Object variables

--- a/scss/components/_section-divider.scss
+++ b/scss/components/_section-divider.scss
@@ -13,7 +13,7 @@ $section-divider-height: 40px;
 
 .section-divider {
   @extend .cf;
-  @extend .push21--bottom;
+  @extend .push25--bottom;
   background: $section-divider-bg;
   height: $section-divider-height;
   margin: 0;

--- a/scss/generic/_helper.scss
+++ b/scss/generic/_helper.scss
@@ -9,24 +9,28 @@
 .border--left { border-left: $border-width solid $border-color; }
 
 // Define common push values
-.push7--right { margin-right: 7px; }
-.push9--bottom { margin-bottom: 9px; }
-.push10--left { margin-left: 10px; }
-.push10--right { margin-right: 10px; }
-.push15--top { margin-top: 15px; }
-.push18--bottom { margin-bottom: 18px; }
-.push18--top { margin-top: 18px; }
-.push21--bottom { margin-bottom: 21px; }
-.push25--bottom { margin-bottom: 25px; }
-.push25--left { margin-left: 25px; }
-.push25--right { margin-right: 25px; }
-.push30--left { margin-left: 30px; }
-.push30--right { margin-right: 30px; }
-.push45--bottom { margin-bottom: 45px; }
-.push45--top { margin-top: 45px; }
-.push70--top { margin-top: 70px; }
-.push85--top { margin-top: 85px; }
-.push90--bottom { margin-bottom: 90px; }
+@each $size in $push-sizes {
+  // Push on all sides
+  .push#{$size} { margin: #{$size}px; }
+
+  // Push on specific sizes
+  .push#{$size}--bottom { margin-bottom: #{$size}px; }
+  .push#{$size}--left { margin-left: #{$size}px; }
+  .push#{$size}--right { margin-right: #{$size}px; }
+  .push#{$size}--top { margin-top: #{$size}px; }
+
+  // Push on top and bottom
+  .push#{$size}--ends {
+    margin-bottom: #{$size}px;
+    margin-top: #{$size}px;
+  }
+
+  // Push on left and right
+  .push#{$size}--sizes {
+    margin-left: #{$size}px;
+    margin-right: #{$size}px;
+  }
+}
 
 // Define .hidden helper for hiding elements
 .hidden {

--- a/scss/variables/_push.scss
+++ b/scss/variables/_push.scss
@@ -1,0 +1,3 @@
+// Sizes in pixels to create `.push{size}` helpers for
+//   e.g. .push7, .push7--ends, .push7--sides, .push7--top, .push7--bottom, etc
+$push-sizes: 7, 10, 18, 25, 30, 45, 70, 90 !default;

--- a/server/docs/margin.md
+++ b/server/docs/margin.md
@@ -1,0 +1,29 @@
+---
+title: Margins
+---
+There are predefined helpers and sizes used for adding margin to elements.
+
+The sizes available are `7`, `10`, `18`, `25`, `30`, `45`, `70`, and `90`.
+
+The available helpers are:
+
+* `.push{size}` - add margin of `{size}px` on all sides
+* `.push{size}--ends` - add margin of `{size}px` to the top and bottom
+* `.push{size}--sides` - add margin of `{size}px` to the left and right sides
+* `.push{size}--bottom` - add margin of `{size}px` to the bottom
+* `.push{size}--left` - add margin of `{size}px` to the left
+* `.push{size}--right` - add margin of `{size}px` to the right
+* `.push{size}--top` - add margin of `{size}px` to the top
+
+```html
+<div class="row push25--ends">
+</div>
+```
+
+Or you can use them when defining new SCSS classes:
+
+```css
+.name {
+  @extend .push25--ends;
+}
+```


### PR DESCRIPTION
We were previously defining one-off `push` (margin) helpers based on each component. However, it always makes it a pain to have to update `underdog-styles`, when we need to add `push25--top` even though we already have `--bottom`, `--left`, and `--right`. So instead, what we are doing in this PR is defining common margins that should be used across all projects, and defining a known set of helper classes for each size.

![image](https://cloud.githubusercontent.com/assets/1320353/14256945/32e35dbe-fa69-11e5-9465-76782b7921f5.png)

**Note:** We are removing some margin sizes `9`, `15`, `21`, and `85`. These sizes are rarely used and there are other appropriately similar margins we can use instead of them.

Releasing these changes will also require some refactoring to other projects, like `company-dashboard, and`dogtag` both of which use a few of the now deprecated margin widths.

/cc @underdogio/engineering
