### PR TITLE
Remove margin from bottom of .divider

### DIFF
--- a/scss/objects/_divider.scss
+++ b/scss/objects/_divider.scss
@@ -14,7 +14,6 @@ $divider-height: 1px !default;
 $divider-text-bg: $white !default;
 
 .divider {
-  margin-bottom: 1em;
   position: relative;
   text-align: center;
 

--- a/server/docs/divider.md
+++ b/server/docs/divider.md
@@ -3,7 +3,7 @@ title: Divider
 ---
 You can utilize a `.divider` if you need a vertically centered horizontal rule which may contain text.
 
-<div class="row">
+<div class="row push18--bottom">
   <div class="col-6-large-and-up col-12-medium-and-down">
     <div class="divider"></div>
   </div>


### PR DESCRIPTION
When we originally created `.divider` we had a bottom margin added by default, however, after trying to actually use it, we realized that it makes having consistent spacing above and below the `.divider` difficult.

So, in this PR we are removing the `margin-bottom` from `.divider`.

/cc @underdogio/engineering 
