### PR TITLE
Fix spelling error, s/sizes/sides/

### DIFF
--- a/scss/generic/_helper.scss
+++ b/scss/generic/_helper.scss
@@ -26,7 +26,7 @@
   }
 
   // Push on left and right
-  .push#{$size}--sizes {
+  .push#{$size}--sides {
     margin-left: #{$size}px;
     margin-right: #{$size}px;
   }


### PR DESCRIPTION
Well... this is awkward... I misspelled `--sides` when adding in the new `push` classes, and foolish me didn't review my code well enough before merging... whomp whomp :(

This PR fixes that issue by fixing the class name.

/cc @underdogio/engineering 
