### PR TITLE
Support type="email" inputs and add a little spacing between elements

### DIFF
--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -4,12 +4,14 @@ $input-text-height: 40px;
 $input-text-border-width: 1px;
 
 input {
+  &[type=email],
   &[type=text],
   &[type=password] {
     $input-text-vertical-padding: 10px;
 
     border: $input-text-border-width solid $input-text-border-color;
     border-radius: $input-text-border-radius;
+    margin-bottom: $input-text-vertical-padding * 2;
     padding-bottom: $input-text-vertical-padding;
     padding-left: 14px;
     padding-top: $input-text-vertical-padding;
@@ -58,7 +60,6 @@ input {
 .block-label {
   display: block;
   font-size: $block-label-font-size;
-  margin-bottom: 7px;
   width: 100%;
 }
 

--- a/server/docs/forms.md
+++ b/server/docs/forms.md
@@ -15,7 +15,7 @@ title: Forms
 <div class="row">
   <div class="col-6">
     <label class="block-label">First half</label>
-    <input class="block-input" type="text" />
+    <input class="block-input" type="email" />
   </div>
   <div class="col-6">
     <label class="block-label">Second half</label>
@@ -33,7 +33,7 @@ title: Forms
 <div class="row">
   <div class="col-6">
     <label class="block-label">First half</label>
-    <input class="block-input" type="text" />
+    <input class="block-input" type="email" />
   </div>
   <div class="col-6">
     <label class="block-label">Second half</label>


### PR DESCRIPTION
Fixes #37
Fixes #38 

We noticed that we weren't really supporting `type="email"` input forms in the same way as `type="text"` and wanted to add support for them. As well, we wanted to add a little extra spacing to input elements to uncrowd them as much.

/cc @underdogio/engineering
