### PR TITLE
Use 'cursor: auto' for labels

### DIFF
--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -3,6 +3,11 @@
 $input-text-height: 40px;
 $input-text-border-width: 1px;
 
+// Reset the cursor for `label`s since `inuit.css` sets them to `pointer`
+label {
+  cursor: auto;
+}
+
 input {
   &[type=email],
   &[type=text],


### PR DESCRIPTION
Those damn pesky cursors... we want to update the default for `label`s to use `cursor: auto` rather than `cursor: pointer` as is being set by `inuit.css`

/cc @underdogio/engineering
