### PR TITLE
Reset elements cursor to auto

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -6,6 +6,10 @@
 // Mixins
 @import 'mixins';
 
+// Import style resets
+// DEV: Include after `inuit.css` so we reset any styles set by them
+@import 'generic/reset';
+
 // Base styles (e.g. headings)
 @import 'base/headings';
 @import 'base/forms';

--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -3,11 +3,6 @@
 $input-text-height: 40px;
 $input-text-border-width: 1px;
 
-// Reset the cursor for `label`s since `inuit.css` sets them to `pointer`
-label {
-  cursor: auto;
-}
-
 input {
   &[type=email],
   &[type=text],

--- a/scss/generic/_reset.scss
+++ b/scss/generic/_reset.scss
@@ -1,0 +1,10 @@
+// Reset `cursor:pointer` from `inuit.css`
+// https://github.com/csswizardry/inuit.css/blob/c737cf1694e9db4d597f8d081091b8529614e370/generic/_reset.scss#L66-L73
+label,
+input,
+textarea,
+button,
+select,
+option {
+  cursor: auto;
+}


### PR DESCRIPTION
Fixes #42 

Change to make @cmuir less cranky :P

The problem is that `inuit.css` resets a few elements cursor's to `pointer` which some people _cough_ chris _cough_ find weird/odd.

So, we are resetting them to `auto`, which means the browser gets to decide what they are.

/cc @underdogio/engineering
