### PR TITLE
Update eslint-config-underdog to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "async": "1.5.2",
     "bower": "1.7.7",
+    "eslint-config-underdog": "1.1.2",
     "express": "4.13.4",
     "express-handlebars": "3.0.0",
     "gemini": "2.1.1",


### PR DESCRIPTION
Adds eslint-config-underdog as a dependency. Closes #50.

/cc @underdogio/engineering
