### PR TITLE
Keep track of z-index values in a Sass map

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -15,6 +15,7 @@
 @import 'variables/font';
 @import 'variables/colors';
 @import 'variables/borders';
+@import 'variables/layers';
 @import 'variables/media-queries';
 @import 'variables/push';
 @import 'variables/transitions';

--- a/scss/variables/_layers.scss
+++ b/scss/variables/_layers.scss
@@ -1,0 +1,9 @@
+$layer: (
+  base: 0,
+  header: 1,
+  modals: 2
+);
+
+@function layer($key) {
+  @return map-get($layer, $key);
+}


### PR DESCRIPTION
Adds a file where we can keep track of z-index values. Prevents the presence of `z-index: 99999999999999999`.

Values are stored in a Sass Map. I also added a helper function to get values from the sass map. Usage:

```
z-index: layer(modals);
```

/cc @underdogio/engineering
