### PR TITLE
Fix typo when extending from '.icon--small'

### DIFF
--- a/scss/objects/_icons.scss
+++ b/scss/objects/_icons.scss
@@ -54,7 +54,7 @@
 .icon-small-arrow {
   & :before {
     @extend .icon-arrow;
-    @extend .icon-small;
+    @extend .icon--small;
     color: map-get($icon-color-overrides, 'small-arrow');
   }
 }


### PR DESCRIPTION
There's a small typo in the `.icon-small-arrow` class that is breaking company dashboard. 

I'm not sure how this wasn't caught when building the stylesheet, but I confirmed that this fixes company dashboard.

/cc @underdogio/engineering
