### PR TITLE
Increase base font size, line height, and spacing units to 14px

### DIFF
--- a/scss/variables/_font.scss
+++ b/scss/variables/_font.scss
@@ -1,12 +1,13 @@
 // Base sizes
-$p-font-size: 13px;
-$alpha-font-size: 30px;
-$beta-font-size: 20px;
-$gamma-font-size: 15px;
+$p-font-size: 14px;
+$alpha-font-size: 32px;
+$beta-font-size: 24px;
+$gamma-font-size: 18px;
 
 // Base font setup
 $base-font-size: $p-font-size;
-$base-line-height: 18px;
+// Use the golden ratio for line height.
+$base-line-height: floor(14px * 1.618);
 // Fonts from mocks:
 //   OpenSans - everywhere
 //   OpenSans italics - "This batch is currently *free*..." in "03_new_signup_add_payment"
@@ -19,7 +20,7 @@ $base-font-family: 'Open Sans', 'Calibri', 'Candara', 'Segoe', 'Segoe UI', 'Opti
 $h1-size: $alpha-font-size; // .alpha
 $h2-size: $beta-font-size; // .beta
 $h3-size: $gamma-font-size; // .gamma
-$h4-size: 20px; // .delta // default
+$h4-size: 18px; // .delta // default
 $h5-size: 16px; // .epsilon // default
 $h6-size: 14px; // .zeta // default
 
@@ -29,12 +30,12 @@ $half-spacing-unit: $base-spacing-unit / 2; // default
 $line-height-ratio: $base-line-height / $base-font-size; // default
 
 // Uses OpenSans-Semibold
-$block-label-font-size: 12px;
-$inline-label-font-size: 13px;
-$nested-checkbox-font-size: 10px;
+$block-label-font-size: 14px;
+$inline-label-font-size: 16px;
+$nested-checkbox-font-size: 12px;
 // Has matching 16px line-height for vertical centering with checkbox
 
 // Generic elements
-$comment-font-size: 10px;
-$hr-font-size: 12px;
-$th-small-font-size: 12px;
+$comment-font-size: 12px;
+$hr-font-size: 14px;
+$th-small-font-size: 14px;


### PR DESCRIPTION
This PR increase the base font size and line height. The goal of this is to improve readability and make everything feel less cramped. The increased font-size and spacing between elements also gives our styles have a more premium feel (things that are spaced out more tend to feel more premium).

If you're interested in the rationale behind this, I recommend you read Mark Boulton's post on the use of whitespace in [A List Apart](http://alistapart.com/article/whitespace).

Here are some before and after screenshots of the changes:

**Before**

<img width="1680" alt="old" src="https://cloud.githubusercontent.com/assets/6979137/14919433/d3e619b8-0df6-11e6-8592-15a2167d78eb.png">

**After with larger font sizes**

<img width="1680" alt="screen shot 2016-04-29 at 10 45 33 am" src="https://cloud.githubusercontent.com/assets/6979137/14919601/90bbba98-0df7-11e6-9748-d096d669809f.png">

/cc @underdogio/engineering @cmuir 
