### PR TITLE
Emit sourcemaps for stylesheets

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run clean && npm run build-js && npm run build-sass && cp -R fonts/ dist/fonts/",
     "build-icons": "gulp build-icons",
     "build-js": "mkdir -p dist/js/ && browserify --outfile dist/js/app.js js/*.js",
-    "build-sass": "node-sass --include-path bower_components/ --output dist/css/ --output-style compressed scss/underdog.scss",
+    "build-sass": "node-sass --include-path bower_components/ --output dist/css/ --source-map true --output-style compressed scss/underdog.scss",
     "develop": "nodemon --exec 'npm run build' --watch scss/ --watch js/",
     "gemini-gather": "gemini gather test/visual/*.js",
     "gemini-gui": "gemini-gui test/visual/*.js",

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,12 @@ module.exports = function(cb) {
   app.set('views', __dirname + '/views/');
   app.use('/dist', express.static(__dirname + '/../dist/'));
 
+  // Source files if we're not in production.
+  // DEV: Serving source files enables us to view sourcemaps.
+  if (process.env.NODE_ENV !== 'production') {
+    app.use('/scss', express.static(__dirname + '/../scss/'));
+  }
+
   // Load the sections for the styleguide
   loadSections(path.join(__dirname, '../docs/**/*.md'), function(error, sections) {
     if (error) {


### PR DESCRIPTION
The PR set an option to `node-sass` to emit source maps when building stylesheets. This will allow us to jump directly to the source `.scss` file when inspecting styles in dev tools.

Example:

<img width="381" alt="screen shot 2016-04-29 at 11 16 04 am" src="https://cloud.githubusercontent.com/assets/6979137/14920463/cd1b3ec4-0dfb-11e6-9699-acbc73fd0ce8.png">

We have to serve the source files in order to view the sourcemaps, so this PR also configures the server to serve the `/scss` directory if we are not running in production.

/cc @underdogio/engineering 
