### PR TITLE
Add variables for font-weights

### DIFF
--- a/scss/base/_headings.scss
+++ b/scss/base/_headings.scss
@@ -4,5 +4,5 @@ h3,
 h4,
 h5,
 h6 {
-  font-weight: normal;
+  font-weight: $font-weight-normal;
 }

--- a/scss/generic/_reset.scss
+++ b/scss/generic/_reset.scss
@@ -8,3 +8,10 @@ select,
 option {
   cursor: auto;
 }
+
+b,
+strong {
+  // Set font-weight to prevent text being emboldened to 700.
+  // DEV: Emboldening looks awful.
+  font-weight: $font-weight-bold;
+}

--- a/scss/variables/_buttons.scss
+++ b/scss/variables/_buttons.scss
@@ -1,8 +1,8 @@
 // Button sizing
 $btn-font-size: 13px;
-$btn-font-weight: 700;
+$btn-font-weight: $font-weight-bold;
 $btn-block-font-size: 15px;
-$btn-block-font-weight: 400;
+$btn-block-font-weight: $font-weight-normal;
 
 // Button coloring
 $btn-primary-bg: $green;

--- a/scss/variables/_font.scss
+++ b/scss/variables/_font.scss
@@ -39,3 +39,7 @@ $nested-checkbox-font-size: 12px;
 $comment-font-size: 12px;
 $hr-font-size: 14px;
 $th-small-font-size: 14px;
+
+// Font weights
+$font-weight-normal: 400;
+$font-weight-bold: 600;


### PR DESCRIPTION
Since we are using a non-standard value for font-weights (600 vs. 700), we should keep those values in variables. 

This PR also resets `<b>` and `<strong>` tags to use a font weight of `600`. Right now the fonts were being emboldened with a font weight of `700` because we are importing the Open Sans font family with font weights 400 and 700. Setting those tags to use the font weight we have available will make bold text look much better.

/cc @underdogio/engineering 
