### PR TITLE
Set build script to re-run when assets change

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-icons": "gulp build-icons",
     "build-js": "mkdir -p dist/js/ && browserify --outfile dist/js/app.js js/*.js",
     "build-sass": "node-sass --include-path bower_components/ --output dist/css/ --source-map true --output-style compressed scss/underdog.scss",
-    "develop": "nodemon --exec 'npm run build' --watch scss/ --watch js/",
+    "develop": "nodemon --exec 'npm run build' --watch scss/ --watch js/ --ext scss",
     "gemini-gather": "gemini gather test/visual/*.js",
     "gemini-gui": "gemini-gui test/visual/*.js",
     "gemini-test": "gemini test --reporter html --reporter flat test/visual/*.js",


### PR DESCRIPTION
Nodemon needs a list of extensions to watch when passing it a custom script with the `--exec` option, otherwise it will never re-run the script. This PR adds the `--ext` option to the `develop` script and pass it the `scss` and `js` extensions.

Also, I moved the `js` extension from the `start-develop` script to the `develop` script. It makes more sense to have that extension next to the script that builds JavaScript files.

/cc @underdogio/engineering 
