### PR TITLE
Block Label Styles

### DIFF
--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -76,8 +76,12 @@ input {
 // Custom form elements
 .block-label {
   @include transition(color);
+  color: $block-label-color;
   display: block;
   font-size: $block-label-font-size;
+  font-weight: $block-label-font-weight;
+  // Offset label to line up with input border radius.
+  margin-bottom: $block-label-margin;
   width: 100%;
 }
 

--- a/scss/variables/_font.scss
+++ b/scss/variables/_font.scss
@@ -27,6 +27,7 @@ $h6-size: 14px; // .zeta // default
 // Set up spacing for baseline and between elements
 $base-spacing-unit: $base-line-height; // default
 $half-spacing-unit: $base-spacing-unit / 2; // default
+$quarter-spacing-unit: $base-spacing-unit / 4; // default
 $line-height-ratio: $base-line-height / $base-font-size; // default
 
 // Uses OpenSans-Semibold

--- a/scss/variables/_forms.scss
+++ b/scss/variables/_forms.scss
@@ -8,6 +8,8 @@ $input-checkbox-border-color: $gray-xdc;
 $input-checkbox-checked-bg: $dark-gray;
 $nested-checkbox-color: $dark-gray;
 $block-label-color: $dark-gray;
+$block-label-font-weight: $font-weight-bold;
+$block-label-margin: $quarter-spacing-unit;
 $block-label-error-color: $red;
 
 // Border radius


### PR DESCRIPTION
Depends on #61.

This PR updates the styles for the `.block-label` to match up with what's in the UI kit.

Screenshot:

<img width="1475" alt="screen shot 2016-04-29 at 12 05 46 pm" src="https://cloud.githubusercontent.com/assets/6979137/14921931/c988e980-0e02-11e6-94ab-a3859fef2629.png">

/cc @underdogio/engineering 
