### PR TITLE
Change input border color on hover and focus

### DIFF
--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -7,6 +7,7 @@ input {
   &[type=email],
   &[type=text],
   &[type=password] {
+    @include transition(background, border);
     $input-text-vertical-padding: 10px;
 
     border: $input-text-border-width solid $input-text-border-color;
@@ -17,8 +18,19 @@ input {
     padding-top: $input-text-vertical-padding;
   }
 
+  &:hover {
+    border-color: $input-text-hover-border-color;
+  }
+
+  &:focus {
+    border-color: $input-text-focus-border-color;
+    outline: 0;
+  }
+
   &:disabled {
     background: $input-text-disabled-bg;
+    // Don't allow disabled inputs to be interacted with.
+    pointer-events: none;
   }
 
   &.input--error {
@@ -58,6 +70,7 @@ input {
 
 // Custom form elements
 .block-label {
+  @include transition(color);
   display: block;
   font-size: $block-label-font-size;
   width: 100%;

--- a/scss/variables/_forms.scss
+++ b/scss/variables/_forms.scss
@@ -1,5 +1,7 @@
 // Form coloring
 $input-text-border-color: $gray-xdc;
+$input-text-hover-border-color: $purple;
+$input-text-focus-border-color: $whitish-black;
 $input-text-disabled-bg: $gray-xf3;
 $input-text-error-border-color: $red;
 $input-checkbox-border-color: $gray-xdc;


### PR DESCRIPTION
Make text inputs feel more interactive by changing their border color when the user interacts with it.

/cc @underdogio/engineering 
