### PR TITLE
Set label cursor to pointer

### DIFF
--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -3,6 +3,11 @@
 $input-text-height: 40px;
 $input-text-border-width: 1px;
 
+// Let the user know that labels can be clicked.
+label {
+  cursor: pointer;
+}
+
 input {
   &[type=email],
   &[type=text],


### PR DESCRIPTION
Clicking on a label focuses on its associated input field. We should signify to the user that labels can be clicked by changing its cursor to `pointer`.

In order for this to work, we can either:
1. Give matching values for the label's `for` and the input's `id` properties.
   
   ``` html
   <label for="inputId">This is input label</label>
   <input id="inputId" />
   ```
2. Wrap the input within its `label` tag.
   
   ``` html
   <label>
     <span class="block-label">This is input label</span>
     <input type="text" />
   </label>
   ```

I'm a fan of the second approach as I think it's cleaner, but not opposed to the first approach.

/cc @underdogio/engineering 
