### PR TITLE
Setup Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/bin/underdog-styles
+++ b/bin/underdog-styles
@@ -10,7 +10,8 @@ require('../')(function(error, app) {
   }
 
   // Start up the app
-  app.listen(9008, function () {
-    console.log('underdog-styles is running at http://localhost:9008/');
+  var port = process.env.PORT || 9008;
+  app.listen(port, function () {
+    console.log('underdog-styles is running at http://localhost:%s/', port);
   });
 });


### PR DESCRIPTION
I created a free dyno on Heroku so the entire team can view changes to `underdog-styles` as we work on it. It's hosted at http://underdog-styles.herokuapp.com/. 

But before the app can run on heroku, we need to have `underdog-styles` bind to the port provided by the `process.env.PORT` environment variable, and we need to tell Heroku to build the app before starting up. 

/cc @underdogio/engineering 

**P.S.** The app is running fine right now because I manually deployed this branch to Heroku.
