### PR TITLE
Add styles for full screen app layout

### DIFF
--- a/docs/app-container.md
+++ b/docs/app-container.md
@@ -1,0 +1,45 @@
+---
+title: App Container
+---
+
+The `.app-container` allows you create a full screen app layout that keeps the header in view at all times but allows you to scroll the main content.
+
+The main content will stretch to fill the height of the container, minus the header, and can be scrolled if it contains more content than can fit into the height of the viewport.
+
+There should be just one `.app-container` on a page, and it should always to applied to the top most node of the page layout.
+
+NOTE: The `.app-container` in this example has a restricted width and height, but by default it will match the width and height of the viewport.
+
+<div class="app-container" style="width: 100%; height: 25em;">
+  <div class="app-container__header header">
+    <div class="header__logo">
+      <img src="" alt="Logo" width="217" height="45" />
+    </div>
+    <div class="header__nav">
+      <span>Lionel Itchy</span>
+      <span class="icon icon-arrow" />
+    </div>
+  </div>
+  <div class="app-container__content greybox">
+    <p>
+      Cursus eu quibusdam lectus itaque pulvinar, ullamco facilisi sunt, praesent placerat eaque? Minima minima sunt malesuada perferendis vero condimentum sapien, beatae eleifend debitis elementum luctus adipisci delectus iure penatibus incidunt accusamus aenean architecto dis sequi nunc! Nunc a excepteur taciti, natus sollicitudin, feugiat ante, inventore commodo sollicitudin primis delectus, fugit sunt! Felis minus ante repellat voluptas. Aliqua ornare egestas blandit vel nascetur proin expedita, ultricies maecenas. Ipsam eaque, possimus quam sit primis! Ut viverra wisi nullam temporibus ullamcorper officia morbi erat metus anim ullamcorper. Hic, nibh tortor sed quo nostrud porta accusantium impedit congue molestias. Praesent, enim quod nostrum sociosqu.
+    </p>
+    <p>
+      Nobis blanditiis quo potenti etiam aut netus facere sagittis lectus quia rutrum! Aliquid porta, numquam lacinia, duis netus voluptatum, quasi. Blanditiis molestias. Iusto magnis, laborum quos, non eros eleifend rhoncus corrupti voluptates, mattis lectus et ab euismod dui tortor facilisis? Fugit feugiat. Nibh eleifend distinctio! Omnis commodi metus! Ipsam felis sit etiam minima lacinia excepturi, cursus dolor tortor consequuntur odit, cum ea curabitur, dictumst, soluta recusandae maxime nulla! Commodo sint laboris. Condimentum, a, potenti, ultricies, elit qui perferendis, lorem labore, posuere, venenatis soluta imperdiet? Quo? Sunt, turpis tincidunt nec montes facilisis nostrud! Primis gravida rhoncus architecto? Cras, imperdiet corrupti, eius.
+    </p>
+    <p>
+      Rhoncus interdum pretium. Nunc justo? Vero hic sociis expedita, quisque semper aliqua incididunt urna, culpa rhoncus corporis dolor, aliquam officia illum? Sapien, nascetur mus. Soluta quaerat, exercitation euismod ligula consequatur. Nulla fringilla ridiculus quisquam, ultricies orci, nec error distinctio fugit, iste quasi doloribus viverra corporis risus deleniti fuga architecto magni donec suspendisse maecenas laboriosam aliquam quas! Quia risus nostrud taciti, occaecati platea repellendus laboris, etiam erat, quas at lacinia eget fusce deserunt molestie tortor necessitatibus curae vehicula sequi, doloribus suspendisse! Aut praesentium adipisci aliquip animi eu expedita torquent! Dui? Occaecat? Illo! Qui? Nisl magnis, perspiciatis porttitor? Dolor dolorem provident lacinia.
+    </p>
+  </div>
+</div>
+
+```html
+<div class="app-container">
+  <div class="app-container__header">
+    Header in here
+  </div>
+  <div class="app-container__content">
+    Content
+  </div>
+</div>
+```

--- a/scss/objects/_app-container.scss
+++ b/scss/objects/_app-container.scss
@@ -1,0 +1,23 @@
+// Use to create a full screen layout that only allows the main
+// content to be scrolled.
+// SEE app-container.md
+.app-container {
+  display: flex;
+  height: 100vh;
+  flex-direction: column;
+  overflow-y: hidden;
+  width: 100vw;
+}
+
+.app-container__header {
+  // Don't allow the size of the header to change.
+  flex: 0 0 auto;
+}
+
+.app-container__content {
+  // Stretch the height of the main content to match the height
+  // of the viewport.
+  flex: 1 1 auto;
+  // Allow main content to be scrolled.
+  overflow-y: scroll;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -3,6 +3,7 @@
 
 // Generic elements (e.g. grid)
 @import 'objects/alerts';
+@import 'objects/app-container';
 @import 'objects/buttons';
 @import 'objects/container';
 @import 'objects/divider';


### PR DESCRIPTION
Adds an object `.app-container` that allows us to create a full screen layout that always keeps the header in view but allow us to scroll the main content independently.

Here's a gif showing `.app-container` in action:

![App container demo](https://cloud.githubusercontent.com/assets/6979137/14989937/5d1236a2-1128-11e6-93bb-0f5a8de40681.gif)

In this gif `.app-container` has it's width and height restricted so that it doesn't overflow the page, and so we can test that `.app-container__content` is scrollable.

/cc @underdogio/engineering 
