### PR TITLE
Add aside-layout object for sidebar + content layouts

### DIFF
--- a/docs/aside-layout.md
+++ b/docs/aside-layout.md
@@ -1,0 +1,65 @@
+---
+title: Aside Layout
+---
+
+The `.aside-layout` creates a sidebar + content layout where the sidebar is always fixed in view,
+but the content is allowed to scroll independently.
+
+In order for this layout to work, `.aside-layout` must be wrapped in an element that has a set
+height, like `.app-container`.
+
+<div class="app-container" style="height: 20em; width: 100%;">
+  <div class="app-container__header header">
+    <div class="header__logo">
+      <img class="hidden--small" src="//placehold.it/217x45" alt="Placeholder logo" width="217" height="45">
+      <img class="hidden--medium-and-up" src="//placehold.it/43x45" alt="Placeholder logo" width="43" height="45">
+    </div>
+    <div class="header__nav">
+      <span>Lionel Itchy</span>
+      <span class="icon icon-arrow" />
+    </div>
+  </div>
+  <div class="app-container__content aside-layout">
+    <div class="aside-layout__sidebar">
+      <div class="sidebar">
+        <div class="sidebar__title">
+          Sidebar links
+        </div>
+        <ul class="sidebar__nav">
+          <li>
+            <a href="#">First link</a>
+          </li>
+          <li>
+            <a href="#" class="link--active">Active link</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="aside-layout__content">
+      <p>
+        Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
+      </p>
+
+      <p>
+        Scelerisque feugiat. Nulla fusce voluptatum, per molestie scelerisque. Congue ornare nostra est? Vehicula molestias, natoque quos massa mattis, natoque repellendus urna, quibusdam, autem imperdiet? Lacinia aperiam ipsum netus. Qui incidunt leo adipiscing excepturi iste nesciunt aliquid? Class conubia, ullamco. Cubilia quidem dolore sociis consectetur dolorum minus? Ligula gravida placerat, quis? Quasi lobortis, aliquet mauris erat venenatis exercitationem fringilla? Magni consequuntur. Ullamcorper! Eleifend, minima curabitur labore, optio pellentesque porta, hymenaeos porttitor, nunc taciti! Mollitia risus consequatur senectus deleniti, cillum, venenatis dignissim, scelerisque. Laborum mollis accumsan! Leo consectetur, occaecat ab! Dolore numquam, eveniet mattis posuere, sodales consectetur, ipsa, eget mi cupidatat rhoncus.
+      </p>
+
+      <p>
+        Harum quas congue accusamus per? Diamlorem ligula rem cupidatat aliquet. Ab condimentum ullamcorper temporibus eius perferendis elementum wisi magnis incididunt? Dolorem exercitationem placeat eveniet ipsam pretium ullamco? Iaculis! Ipsa veniam nonummy cillum? Magnam lorem, praesent aspernatur. Quia nonummy quibusdam! Habitasse dapibus nascetur laboris class, nullam, tempus totam autem? Aute dignissim malesuada ornare a qui suspendisse hac, tempor, consequuntur diam veritatis, nullam eleifend tempore quis augue porro interdum habitasse condimentum cupidatat! Montes rhoncus. Corporis quos ut magna nulla leo maiores voluptates rerum eros inventore modi! Sapiente explicabo excepturi? Varius! Fermentum elementum, arcu euismod curae distinctio blandit sollicitudin malesuada praesent inceptos fugiat.
+      </p>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="app-container">
+  <div class="app-container__content aside-layout">
+    <div class="aside-layout__sidebar">
+      Sidebar goes in here
+    </div>
+    <div class="aside-layout__content">
+      Content goes in here
+    </div>
+  </div>
+</div>
+```

--- a/scss/objects/_aside-layout.scss
+++ b/scss/objects/_aside-layout.scss
@@ -1,0 +1,28 @@
+// Creates a sidebar + content layout where the sidebar is always fixed in view,
+// but the content is allowed to scroll independently. Works best when the parent container has a set height.
+// SEE: aside-layout.md
+.aside-layout {
+  display: flex;
+  // Fill the height of the parent container.
+  height: 100%;
+  // Prevent the entire element from being scrolled.
+  overflow-y: hidden;
+}
+
+.aside-layout__sidebar,
+.aside-layout__content {
+  // Fill the height of the parent container
+  height: 100%;
+}
+
+.aside-layout__sidebar {
+  // Don't modify the size of the sidebar
+  flex: 0 0 auto;
+}
+
+.aside-layout__content {
+  // Allow the content to the right of the sidebar to stretch to fill the remaining space.
+  flex: 1 1 auto;
+  // Make the content scrollable.
+  overflow-y: scroll;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -4,6 +4,7 @@
 // Generic elements (e.g. grid)
 @import 'objects/alerts';
 @import 'objects/app-container';
+@import 'objects/aside-layout';
 @import 'objects/buttons';
 @import 'objects/container';
 @import 'objects/divider';


### PR DESCRIPTION
Adds an `.aside-layout` object that creates a sidebar + content layout where the sidebar is always fixed in view but the content can be scrolled independently.

Works best when used within an `.app-container`.

![untitled gif](https://cloud.githubusercontent.com/assets/6979137/14991152/f49b8b68-112d-11e6-9072-a8bdacef5fe0.gif)

/cc @underdogio/engineering 
