### PR TITLE
Replace sidebar margin with padding on all sides

### DIFF
--- a/scss/components/_sidebar.scss
+++ b/scss/components/_sidebar.scss
@@ -12,7 +12,7 @@
 // ======
 
 .sidebar {
-  @extend .push25--left;
+  padding: $sidebar-padding;
 }
 
 .sidebar__title {

--- a/scss/variables/_grid.scss
+++ b/scss/variables/_grid.scss
@@ -1,5 +1,6 @@
 // Horizontal spacing
 $base-spacing-width: 14px !default;
+$double-spacing-width: 28px !default;
 
 // Grid
 $columns: 12;

--- a/scss/variables/_sidebar.scss
+++ b/scss/variables/_sidebar.scss
@@ -1,2 +1,2 @@
-// Sidebar coloring
+$sidebar-padding: $double-spacing-width;
 $sidebar-title-color: $dark-gray;


### PR DESCRIPTION
Closes #71.

The sidebar currently has just a left margin which looks weird if the element to the right of it does not have padding of its own, or if the element above it doesn't have a bottom margin. 

This PR replaces the margin with padding on all sides.

Before:

<img width="440" alt="sidebar_before" src="https://cloud.githubusercontent.com/assets/6979137/14991516/ba986a9c-112f-11e6-9927-e54efe44a29c.png">

After:

<img width="584" alt="sidebar_after" src="https://cloud.githubusercontent.com/assets/6979137/14991521/c323607c-112f-11e6-81ce-5daf436cd423.png">

/cc @underdogio/engineering 
