### PR TITLE
Fix typo in header documentation example

### DIFF
--- a/docs/header.md
+++ b/docs/header.md
@@ -15,10 +15,10 @@ To make a header sticky, apply the `.header--fixed` modifier class to it.
 
 ```html
 <div class="header">
-  <div class="headerlogo">
+  <div class="header__logo">
     <img src="..." alt="..." width="217" height="45" />
   </div>
-  <div class="headernav">
+  <div class="header__nav">
     <span>Lionel Itchy</span>
     <span class="icon icon-arrow" />
   </div>


### PR DESCRIPTION
Fixes #69 (giggidy).

Header elements in the example were missing underscores in their classes. Not anymore.

/cc @underdogio/engineering 
