### PR TITLE
Replace empty image with placeholder

### DIFF
--- a/docs/app-container.md
+++ b/docs/app-container.md
@@ -13,7 +13,8 @@ NOTE: The `.app-container` in this example has a restricted width and height, bu
 <div class="app-container" style="width: 100%; height: 25em;">
   <div class="app-container__header header">
     <div class="header__logo">
-      <img src="" alt="Logo" width="217" height="45" />
+      <img class="hidden--small" src="//placehold.it/217x45" alt="Placeholder logo" width="217" height="45">
+      <img class="hidden--medium-and-up" src="//placehold.it/43x45" alt="Placeholder logo" width="43" height="45">
     </div>
     <div class="header__nav">
       <span>Lionel Itchy</span>


### PR DESCRIPTION
Replaces the empty image in the header within the `.app-container` example with a placeholder image.

<img width="1484" alt="screen shot 2016-05-03 at 2 14 21 pm" src="https://cloud.githubusercontent.com/assets/6979137/14993584/811af514-1139-11e6-8fa8-379c8af8c43b.png">

/cc @underdogio/engineering 
