### PR TITLE
Add missing sides to border helpers

### DIFF
--- a/scss/generic/_helper.scss
+++ b/scss/generic/_helper.scss
@@ -7,6 +7,8 @@
 // Define custom border helpers
 .border--bottom { border-bottom: $border-width solid $border-color; }
 .border--left { border-left: $border-width solid $border-color; }
+.border--right { border-right: $border-width solid $border-color; }
+.border--top { border-top: $border-width solid $border-color; }
 
 // Define common push values
 @each $size in $push-sizes {


### PR DESCRIPTION
We were missing `.border--top` and `.border--right` helper classes

@underdogio/engineering 
