### PR TITLE
Style disabled nav links

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -18,9 +18,12 @@ A navigation link with the class `.nav-link` and `.nav-link--active` for active 
 
 <a href="#" class="nav-link nav-link--active">I am an active nav-link</a>
 
+<span class="nav-link" disabled="true">I am a disabled nav-link</span>
+
 ```html
 <a href="#" class="nav-link">I am a nav-link</a>
 <a href="#" class="nav-link nav-link--active">I am an active nav-link</a>
+<span class="nav-link" disabled="true">I am a disabled nav-link</span>
 ```
 
 ## Menu link

--- a/scss/objects/_links.scss
+++ b/scss/objects/_links.scss
@@ -12,6 +12,12 @@
   &:hover {
     text-decoration: underline;
   }
+
+  &[disabled] {
+    color: $nav-link-disabled-color;
+    cursor: default;
+    text-decoration: none;
+  }
 }
 
 // Active nav-link (element is selected)

--- a/scss/variables/_links.scss
+++ b/scss/variables/_links.scss
@@ -2,4 +2,5 @@
 $link-color: $purple;
 $nav-link-color: $whitish-black;
 $nav-link-active-color: $purple;
+$nav-link-disabled-color: $dark-gray;
 $menu-link-color: $purple;


### PR DESCRIPTION
Adds styles for disabled `.nav-link`s.

For context, this is for displaying a disabled link for a batch that the logged in company user does not have access to.

<img width="717" alt="screen shot 2016-05-03 at 7 16 20 pm" src="https://cloud.githubusercontent.com/assets/6979137/15001196/8b9fa154-1163-11e6-92ee-459575be8d40.png">

/cc @underdogio/engineering 
