### PR TITLE
Set html overflow-y to auto scroll

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -12,6 +12,7 @@
 
 // Base styles (e.g. headings)
 @import 'base/headings';
+@import 'base/html';
 @import 'base/forms';
 @import 'base/links';
 @import 'base/lists';

--- a/scss/base/_html.scss
+++ b/scss/base/_html.scss
@@ -1,0 +1,4 @@
+html {
+  // Only show a scrollbar if we have to
+  overflow-y: auto;
+}


### PR DESCRIPTION
Right now the `html` element is always showing a scrollbar even if we don't need it. This looks awkward if we have some elements in the page that also have their own scroll bars, like within an `.aside-layout`.

The downside to this change is if the length of the page were to increase, a scroll bar would appear and push everything slightly to the left to the left, but... I think that's still better than always showing two scroll bars right next to each other on the same page. 

Here's a screenshot of what I mean:

<img width="936" alt="screen shot 2016-05-04 at 9 00 40 am" src="https://cloud.githubusercontent.com/assets/6979137/15014911/ba73f156-11d6-11e6-8297-1175ef147cf6.png">

/cc @underdogio/engineering 
