### PR TITLE
Fix scrolling within aside layout content

### DIFF
--- a/scss/objects/_app-container.scss
+++ b/scss/objects/_app-container.scss
@@ -22,5 +22,11 @@
   // of the viewport.
   flex: 1 1 auto;
   // Allow main content to be scrolled.
-  overflow-y: scroll;
+  overflow-y: auto;
+
+  & > * {
+    // Since .app-container__content has its display mode to flex, the first child
+    // will only take up the space that it needs. We want it to take up the full width of the screen.
+    width: 100%;
+  }
 }

--- a/scss/objects/_aside-layout.scss
+++ b/scss/objects/_aside-layout.scss
@@ -15,6 +15,6 @@
 .aside-layout__content {
   // Allow the content to the right of the sidebar to stretch to fill the remaining space.
   flex: 1 1 auto;
-  // Make the content scrollable.
-  overflow-y: scroll;
+  // Allow the content to be scrollable.
+  overflow-y: auto;
 }


### PR DESCRIPTION
Updates `.app-container__content` and `.aside-layout__content` to only show a scrollbar if necessary.

It also updates `.app-container__content` so that the width of its first child is always 100%. 

The reason we want this is because `.app-container__content` has a display mode of `flex`, so its children will only take up the width that it needs. What we actually want is for its children to take up the full width of `.app-container__content` and the app.

Screenshot of what I mean:

<img width="1020" alt="screen shot 2016-05-04 at 9 17 21 am" src="https://cloud.githubusercontent.com/assets/6979137/15015539/844d5b68-11da-11e6-891d-e84c9fafd390.png">

I went with a universal selector here instead of creating another class because in some cases, like in Company Dashboard, we would apply the `.app-container` class to the root element, but its first child would be in multiple components, and each component would have to remember to apply the correct class to its first node.

Since we note in our documentation that this element must contain just a single child, using a universal should be fine. But I'm not opposed to using a class instead.

/cc @underdogio/engineering 
