### PR TITLE
Decrease wrapper padding

### DIFF
--- a/scss/variables/_wrapper.scss
+++ b/scss/variables/_wrapper.scss
@@ -1,3 +1,3 @@
 $wrapper-padding: $gutter-width !default;
-$wrapper-medium-padding: $wrapper-padding * 3 !default;
-$wrapper-large-and-up-padding: $wrapper-padding * 6 !default;
+$wrapper-medium-padding: $wrapper-padding * 2 !default;
+$wrapper-large-and-up-padding: $wrapper-padding * 4 !default;


### PR DESCRIPTION
Decreases wrapper padding ever so slightly.

Before:

<img width="1010" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/15015729/96fa837a-11db-11e6-9279-ed909a569e55.png">

After:

<img width="1010" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15015731/9975dc12-11db-11e6-9fc2-01f3a50352c7.png">

/cc @underdogio/engineering 
