### PR TITLE
Update aside layout example to nest aside layout within app container

### DIFF
--- a/docs/aside-layout.md
+++ b/docs/aside-layout.md
@@ -19,46 +19,53 @@ height, like `.app-container`.
       <span class="icon icon-arrow" />
     </div>
   </div>
-  <div class="app-container__content aside-layout">
-    <div class="aside-layout__sidebar wrapper">
-      <div class="sidebar">
-        <div class="sidebar__title">
-          Sidebar links
+  <div class="app-container__content">
+    <div class="aside-layout">
+      <div class="aside-layout__sidebar wrapper">
+        <div class="sidebar">
+          <div class="sidebar__title">
+            Sidebar links
+          </div>
+          <ul class="sidebar__nav">
+            <li>
+              <a href="#">First link</a>
+            </li>
+            <li>
+              <a href="#" class="link--active">Active link</a>
+            </li>
+          </ul>
         </div>
-        <ul class="sidebar__nav">
-          <li>
-            <a href="#">First link</a>
-          </li>
-          <li>
-            <a href="#" class="link--active">Active link</a>
-          </li>
-        </ul>
       </div>
-    </div>
-    <div class="aside-layout__content wrapper border--left">
-      <p>
-        Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
-      </p>
+      <div class="aside-layout__content wrapper border--left">
+        <p>
+          Quibusdam ante volutpat curae, iure ad maxime cumque morbi! Dicta aptent alias dapibus morbi gravida sit, donec aliquam optio consectetuer delectus sodales ornare sodales, vitae! Sagittis consectetur sociosqu, feugiat impedit dignissim recusandae, ipsa nemo numquam, duis? Molestie eu aute ridiculus! Facere velit maecenas! Voluptate? Sollicitudin imperdiet, impedit vero. Animi, ut morbi, nisi voluptates aperiam! Minim quas potenti placerat varius sint, curae reiciendis reiciendis cillum morbi pharetra, mollitia fames, aperiam perspiciatis tincidunt mauris pretium similique torquent, tincidunt habitasse! Aut, ex, habitant? Accumsan. Saepe taciti dictumst, cras placerat. Sapien porttitor! Suspendisse aliqua aliquid interdum fugit culpa dictum commodi, aperiam temporibus iste hac.
+        </p>
 
-      <p>
-        Scelerisque feugiat. Nulla fusce voluptatum, per molestie scelerisque. Congue ornare nostra est? Vehicula molestias, natoque quos massa mattis, natoque repellendus urna, quibusdam, autem imperdiet? Lacinia aperiam ipsum netus. Qui incidunt leo adipiscing excepturi iste nesciunt aliquid? Class conubia, ullamco. Cubilia quidem dolore sociis consectetur dolorum minus? Ligula gravida placerat, quis? Quasi lobortis, aliquet mauris erat venenatis exercitationem fringilla? Magni consequuntur. Ullamcorper! Eleifend, minima curabitur labore, optio pellentesque porta, hymenaeos porttitor, nunc taciti! Mollitia risus consequatur senectus deleniti, cillum, venenatis dignissim, scelerisque. Laborum mollis accumsan! Leo consectetur, occaecat ab! Dolore numquam, eveniet mattis posuere, sodales consectetur, ipsa, eget mi cupidatat rhoncus.
-      </p>
+        <p>
+          Scelerisque feugiat. Nulla fusce voluptatum, per molestie scelerisque. Congue ornare nostra est? Vehicula molestias, natoque quos massa mattis, natoque repellendus urna, quibusdam, autem imperdiet? Lacinia aperiam ipsum netus. Qui incidunt leo adipiscing excepturi iste nesciunt aliquid? Class conubia, ullamco. Cubilia quidem dolore sociis consectetur dolorum minus? Ligula gravida placerat, quis? Quasi lobortis, aliquet mauris erat venenatis exercitationem fringilla? Magni consequuntur. Ullamcorper! Eleifend, minima curabitur labore, optio pellentesque porta, hymenaeos porttitor, nunc taciti! Mollitia risus consequatur senectus deleniti, cillum, venenatis dignissim, scelerisque. Laborum mollis accumsan! Leo consectetur, occaecat ab! Dolore numquam, eveniet mattis posuere, sodales consectetur, ipsa, eget mi cupidatat rhoncus.
+        </p>
 
-      <p>
-        Harum quas congue accusamus per? Diamlorem ligula rem cupidatat aliquet. Ab condimentum ullamcorper temporibus eius perferendis elementum wisi magnis incididunt? Dolorem exercitationem placeat eveniet ipsam pretium ullamco? Iaculis! Ipsa veniam nonummy cillum? Magnam lorem, praesent aspernatur. Quia nonummy quibusdam! Habitasse dapibus nascetur laboris class, nullam, tempus totam autem? Aute dignissim malesuada ornare a qui suspendisse hac, tempor, consequuntur diam veritatis, nullam eleifend tempore quis augue porro interdum habitasse condimentum cupidatat! Montes rhoncus. Corporis quos ut magna nulla leo maiores voluptates rerum eros inventore modi! Sapiente explicabo excepturi? Varius! Fermentum elementum, arcu euismod curae distinctio blandit sollicitudin malesuada praesent inceptos fugiat.
-      </p>
+        <p>
+          Harum quas congue accusamus per? Diamlorem ligula rem cupidatat aliquet. Ab condimentum ullamcorper temporibus eius perferendis elementum wisi magnis incididunt? Dolorem exercitationem placeat eveniet ipsam pretium ullamco? Iaculis! Ipsa veniam nonummy cillum? Magnam lorem, praesent aspernatur. Quia nonummy quibusdam! Habitasse dapibus nascetur laboris class, nullam, tempus totam autem? Aute dignissim malesuada ornare a qui suspendisse hac, tempor, consequuntur diam veritatis, nullam eleifend tempore quis augue porro interdum habitasse condimentum cupidatat! Montes rhoncus. Corporis quos ut magna nulla leo maiores voluptates rerum eros inventore modi! Sapiente explicabo excepturi? Varius! Fermentum elementum, arcu euismod curae distinctio blandit sollicitudin malesuada praesent inceptos fugiat.
+        </p>
+      </div>
     </div>
   </div>
 </div>
 
 ```html
 <div class="app-container">
-  <div class="app-container__content aside-layout">
-    <div class="aside-layout__sidebar wrapper">
-      Sidebar goes in here
-    </div>
-    <div class="aside-layout__content wrapper">
-      Content goes in here
+  <div class="app-container__header">
+    Header goes in here
+  </div>
+  <div class="app-container__content">
+    <div class="aside-layout">
+      <div class="aside-layout__sidebar wrapper">
+        Sidebar goes in here
+      </div>
+      <div class="aside-layout__content wrapper">
+        Content goes in here
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
I forgot to update the example for `.aside-layout` when I changed how `.app-container` handles its first child element.

How it looks now (fixed):

<img width="1023" alt="screen shot 2016-05-04 at 12 27 59 pm" src="https://cloud.githubusercontent.com/assets/6979137/15021235/a8c23e3c-11f3-11e6-9df4-560fd12506b2.png">

Here's how it looks (broken) right now in https://underdog-styles.herokuapp.com:

<img width="1480" alt="screen shot 2016-05-04 at 12 28 18 pm" src="https://cloud.githubusercontent.com/assets/6979137/15021249/c50721a2-11f3-11e6-8da5-6b4c1b4f2473.png">

/cc @underdogio/engineering 
