### PR TITLE
Update header height

### DIFF
--- a/docs/app-container.md
+++ b/docs/app-container.md
@@ -15,8 +15,8 @@ NOTE: The `.app-container` in this example has a restricted width and height, bu
 <div class="app-container" style="width: 100%; height: 25em;">
   <div class="app-container__header header">
     <div class="header__logo">
-      <img class="hidden--small" src="//placehold.it/217x45" alt="Placeholder logo" width="217" height="45">
-      <img class="hidden--medium-and-up" src="//placehold.it/43x45" alt="Placeholder logo" width="43" height="45">
+      <img class="hidden--small" src="//placehold.it/190x55" alt="Placeholder logo" width="190" height="55">
+      <img class="hidden--medium-and-up" src="//placehold.it/52x55" alt="Placeholder logo" width="52" height="55">
     </div>
     <div class="header__nav">
       <span>Lionel Itchy</span>

--- a/docs/aside-layout.md
+++ b/docs/aside-layout.md
@@ -11,8 +11,8 @@ height, like `.app-container`.
 <div class="app-container" style="height: 20em; width: 100%;">
   <div class="app-container__header header border--bottom">
     <div class="header__logo">
-      <img class="hidden--small" src="//placehold.it/217x45" alt="Placeholder logo" width="217" height="45">
-      <img class="hidden--medium-and-up" src="//placehold.it/43x45" alt="Placeholder logo" width="43" height="45">
+      <img class="hidden--small" src="//placehold.it/190x55" alt="Placeholder logo" width="190" height="55">
+      <img class="hidden--medium-and-up" src="//placehold.it/52x55" alt="Placeholder logo" width="52" height="55">
     </div>
     <div class="header__nav">
       <span>Lionel Itchy</span>

--- a/docs/header.md
+++ b/docs/header.md
@@ -6,7 +6,7 @@ Our header is a full width header which should not be contained within a `.conta
 To make a header sticky, apply the `.header--fixed` modifier class to it.
 
 <div class="header">
-  <div class="header__logo"><img class="hidden--small" src="//placehold.it/217x45" alt="Placeholder logo" width="217" height="45"><img class="hidden--medium-and-up" src="//placehold.it/43x45" alt="Placeholder logo" width="43" height="45"></div>
+  <div class="header__logo"><img class="hidden--small" src="//placehold.it/190x55" alt="Placeholder logo" width="190" height="55"><img class="hidden--medium-and-up" src="//placehold.it/52x55" alt="Placeholder logo" width="52" height="55"></div>
   <div class="header__nav">
     <div class="hidden--small"><span class="gamma push10--right">Lionel Itchy</span><span class="icon icon-arrow"></span></div>
     <div class="hidden--medium-and-up"><span class="icon icon-menu" aria-hidden="true"></span><span class="gamma"> Menu</span></div>
@@ -16,7 +16,7 @@ To make a header sticky, apply the `.header--fixed` modifier class to it.
 ```html
 <div class="header">
   <div class="header__logo">
-    <img src="..." alt="..." width="217" height="45" />
+    <img src="..." alt="..." width="190" height="55" />
   </div>
   <div class="header__nav">
     <span>Lionel Itchy</span>

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -12,7 +12,7 @@
 // ======
 
 $header-height: 68px;
-$header-logo-height: 45px;
+$header-logo-height: 55px;
 
 .header {
   @extend .cf;


### PR DESCRIPTION
As mentioned in underdogio/dogtag#136 we want to change out the header logo images, but, we are changing the height of the logos, so we need to adjust the height of the `.header__logo` as well.

This PR updates that stuffs.

The new logo sizes are 190x55 for the large logo with text and 52x55 for just the dog head.

/cc @underdogio/engineering 
