### PR TITLE
Replace flexbox within slabs with standard grid

### DIFF
--- a/docs/slab.md
+++ b/docs/slab.md
@@ -6,84 +6,90 @@ Use to display pieces of information within a table or list. To highlight a slab
 
 <ul>
   <li class="slab">
-    <div class="slab__section slab__section--small">
-      <span class="slab__title">Matthew Marrone</span>
-      <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
-    </div>
-    <div class="slab__section slab__section--small">
-      <span class="slab__heading">Desired Roles</span>
-      <span>Software engineer, Mobile developer</span>
-    </div>
-    <div class="slab__section slab__section--large">
-      <span class="slab__heading">In their own words</span>
-      <span>
-        Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
-      </span>
-    </div>
-    <div class="slab__section">
-      <span class="slab__heading">Links</span>
-      <ul>
-        <li>
-          <a href="#">GitHub</a>
-        </li>
-      </ul>
-    </div>
-    <div class="slab__section slab__section--small">
-      <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+    <div class="row">
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__title">Matthew Marrone</span>
+        <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Desired Roles</span>
+        <span>Software engineer, Mobile developer</span>
+      </div>
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__heading">In their own words</span>
+        <span>
+          Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
+        </span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Links</span>
+        <ul>
+          <li>
+            <a href="#">GitHub</a>
+          </li>
+        </ul>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+      </div>
     </div>
   </li>
   <li class="slab slab--featured">
-    <div class="slab__section slab__section--small">
-      <span class="slab__title">Matthew Marrone</span>
-      <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
-    </div>
-    <div class="slab__section slab__section--small">
-      <span class="slab__heading">Desired Roles</span>
-      <span>Software engineer, Mobile developer</span>
-    </div>
-    <div class="slab__section slab__section--large">
-      <span class="slab__heading">In their own words</span>
-      <span>
-        Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
-      </span>
-    </div>
-    <div class="slab__section">
-      <span class="slab__heading">Links</span>
-      <ul>
-        <li>
-          <a href="#">GitHub</a>
-        </li>
-      </ul>
-    </div>
-    <div class="slab__section slab__section--small">
-      <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+    <div class="row">
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__title">Matthew Marrone</span>
+        <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Desired Roles</span>
+        <span>Software engineer, Mobile developer</span>
+      </div>
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__heading">In their own words</span>
+        <span>
+          Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
+        </span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Links</span>
+        <ul>
+          <li>
+            <a href="#">GitHub</a>
+          </li>
+        </ul>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+      </div>
     </div>
   </li>
   <li class="slab">
-    <div class="slab__section slab__section--small">
-      <span class="slab__title">Matthew Marrone</span>
-      <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
-    </div>
-    <div class="slab__section slab__section--small">
-      <span class="slab__heading">Desired Roles</span>
-      <span>Software engineer, Mobile developer</span>
-    </div>
-    <div class="slab__section slab__section--large">
-      <span class="slab__heading">In their own words</span>
-      <span>
-        Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
-      </span>
-    </div>
-    <div class="slab__section">
-      <span class="slab__heading">Links</span>
-      <ul>
-        <li>
-          <a href="#">GitHub</a>
-        </li>
-      </ul>
-    </div>
-    <div class="slab__section slab__section--small">
-      <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+    <div class="row">
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__title">Matthew Marrone</span>
+        <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Desired Roles</span>
+        <span>Software engineer, Mobile developer</span>
+      </div>
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__heading">In their own words</span>
+        <span>
+          Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
+        </span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Links</span>
+        <ul>
+          <li>
+            <a href="#">GitHub</a>
+          </li>
+        </ul>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+      </div>
     </div>
   </li>
 </ul>
@@ -91,30 +97,32 @@ Use to display pieces of information within a table or list. To highlight a slab
 ```html
 <ul>
   <li class="slab">
-    <div class="slab__section slab__section--small">
-      <span class="slab__title">Matthew Marrone</span>
-      <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
-    </div>
-    <div class="slab__section slab__section--small">
-      <span class="slab__heading">Desired Roles</span>
-      <span>Software engineer, Mobile developer</span>
-    </div>
-    <div class="slab__section slab__section--large">
-      <span class="slab__heading">In their own words</span>
-      <span>
-        Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
-      </span>
-    </div>
-    <div class="slab__section">
-      <span class="slab__heading">Links</span>
-      <ul>
-        <li>
-          <a href="#">GitHub</a>
-        </li>
-      </ul>
-    </div>
-    <div class="slab__section slab__section--small">
-      <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+    <div class="row">
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__title">Matthew Marrone</span>
+        <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Desired Roles</span>
+        <span>Software engineer, Mobile developer</span>
+      </div>
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__heading">In their own words</span>
+        <span>
+          Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
+        </span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Links</span>
+        <ul>
+          <li>
+            <a href="#">GitHub</a>
+          </li>
+        </ul>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+      </div>
     </div>
   </li>
 </ul>

--- a/scss/components/_slab.scss
+++ b/scss/components/_slab.scss
@@ -2,43 +2,6 @@
 .slab {
   border-bottom: $slab-border;
   padding: $slab-padding;
-
-  // Collapse all sections into a single column for smaller screens.
-  @include media-query-medium-and-down {
-    .slab__section {
-      // Add spacing between sections.
-      margin-bottom: $slab-section-spacing;
-
-      &:last-child {
-        // No need for the last section to have a bottom margin.
-        margin-bottom: 0;
-      }
-    }
-  }
-
-  // Display everything inline with flexbox once the screen gets wide enough.
-  @include media-query-large-and-up {
-    display: flex;
-    flex-wrap: nowrap;
-
-    // Let each section shrink and stretch as needed, and set a default flex-basis of 15%.
-    .slab__section {
-      flex: 1 1 15%;
-    }
-
-    // Adjust the flex basis for each section
-    .slab__section--small {
-      flex-basis: 25%;
-    }
-
-    .slab__section--medium {
-      flex-basis: 30%;
-    }
-
-    .slab__section--large {
-      flex-basis: 40%;
-    }
-  }
 }
 
 .slab__title,
@@ -58,7 +21,7 @@
 }
 
 .slab__section {
-  padding: $slab-section-padding;
+  margin: $slab-section-margin;
 }
 
 .slab--featured {

--- a/scss/variables/_slab.scss
+++ b/scss/variables/_slab.scss
@@ -1,5 +1,4 @@
 $slab-border: solid $border-width $gray-xdc;
-$slab-padding: ($base-spacing-unit * 2) 0;
-$slab-section-spacing: $base-spacing-unit;
-$slab-section-padding: 0 $base-spacing-width;
+$slab-padding: $base-spacing-unit $base-spacing-width;
+$slab-section-margin: $base-spacing-unit 0;
 $slab-featured-bg: $gray-xf2;


### PR DESCRIPTION
Closes https://github.com/underdogio/company-dashboard/issues/184.

Replaces flexbox within the `slab` component with the standard grid so that spacing between slab sections can match up with the grid.

_Before (Wide viewport)_

<img width="1436" alt="slab section spacing - before wide" src="https://cloud.githubusercontent.com/assets/6979137/15099391/345302ca-1522-11e6-9403-1052c4dfd651.png">

_After (Wide)_

<img width="1549" alt="slab section spacing - after wide" src="https://cloud.githubusercontent.com/assets/6979137/15099393/38800956-1522-11e6-9d19-2ca1aa6be734.png">

_Before (Narrow)_

<img width="414" alt="slab section spacing - before narrow" src="https://cloud.githubusercontent.com/assets/6979137/15099395/4175c0a0-1522-11e6-8b03-22303c3d17a1.png">

_After (Narrow)_

<img width="414" alt="slab section spacing - after narrow" src="https://cloud.githubusercontent.com/assets/6979137/15099397/48bcab76-1522-11e6-8b14-81d38774b609.png">

/cc @underdogio/engineering 
