### PR TITLE
Disable pointer events for elements with a disabled attribute

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -11,6 +11,7 @@
 @import 'generic/reset';
 
 // Base styles (e.g. headings)
+@import 'base/disabled';
 @import 'base/headings';
 @import 'base/html';
 @import 'base/forms';

--- a/scss/base/_disabled.scss
+++ b/scss/base/_disabled.scss
@@ -1,0 +1,4 @@
+[disabled] {
+  cursor: auto;
+  pointer-events: none;
+}

--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -34,8 +34,6 @@ input {
 
   &:disabled {
     background: $input-text-disabled-bg;
-    // Don't allow disabled inputs to be interacted with.
-    pointer-events: none;
   }
 
   &.input--error {

--- a/scss/objects/_links.scss
+++ b/scss/objects/_links.scss
@@ -15,7 +15,6 @@
 
   &[disabled] {
     color: $nav-link-disabled-color;
-    cursor: default;
     text-decoration: none;
   }
 }


### PR DESCRIPTION
Closes #90.

Elements with a `disabled` attribute should not respond to pointer events.

/cc @underdogio/engineering 
