### PR TITLE
Hide horizontal overflow

### DIFF
--- a/scss/base/_html.scss
+++ b/scss/base/_html.scss
@@ -1,4 +1,6 @@
 html {
+  // Hide accidental overflow
+  overflow-x: hidden;
   // Only show a scrollbar if we have to
   overflow-y: auto;
 }


### PR DESCRIPTION
Closes #87.

Hides horizontal overflow. 

Right now something in Company Dashboard is causing a horizontal scrollbar to show up for a split second before the app boots up. Not sure what it is (maybe Google fonts loading in a little late?), but it's probably a good idea to hide horizontal overflow by default.

/cc @underdogio/engineering 
