### PR TITLE
Decrease sidebar title spacing

### DIFF
--- a/scss/components/_sidebar.scss
+++ b/scss/components/_sidebar.scss
@@ -12,7 +12,7 @@
 // ======
 
 .sidebar__title {
-  @extend .push25--bottom;
+  @extend .push10--bottom;
   color: $sidebar-title-color;
 }
 


### PR DESCRIPTION
Closes #86.

Decreases bottom margin of sidebar titles.

_Before_:

<img width="1440" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/15099497/c31fdae4-1524-11e6-9383-0659df4955a7.png">

_After_:

<img width="1434" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15099496/c1441668-1524-11e6-91c7-9770ccea2b13.png">
