### PR TITLE
Remove outline on button focus

### DIFF
--- a/scss/objects/_buttons.scss
+++ b/scss/objects/_buttons.scss
@@ -63,6 +63,10 @@
   &:active {
     background: darken($background, $btn-hover-darken);
   }
+
+  &:focus {
+    outline: 0;
+  }
 }
 @mixin button-disabled($background, $color) {
   &.btn--disabled {


### PR DESCRIPTION
Closes #88.

Removes the default blue outline from buttons on focus.

_Before_:

<img width="1480" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/15099521/5cb3faf0-1525-11e6-932d-68e017d1613a.png">

_After_:

<img width="1451" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15099523/67f47c8c-1525-11e6-8fd1-e17d7882a05a.png">

/cc @underdogio/engineering 
