### PR TITLE
Vertically align icons with labels

### DIFF
--- a/docs/icons.md
+++ b/docs/icons.md
@@ -3,27 +3,27 @@ title: Icons
 ---
 
 <ul>
-  <li><span class="icon icon-arrow"> Arrow</span></li>
-  <li><span class="icon icon-back"> Back</span></li>
-  <li><span class="icon icon-close"> Close</span></li>
-  <li><span class="icon icon-copy-link"> Copy link</span></li>
-  <li><span class="icon icon-dribble"> Dribble</span></li>
-  <li><span class="icon icon-filter"> Filter</span></li>
-  <li><span class="icon icon-github"> GitHub</span></li>
-  <li><span class="icon icon-linkedin"> LinkedIn</span></li>
-  <li><span class="icon icon-location"> Location</span></li>
-  <li><span class="icon icon-locked"> Locked</span></li>
-  <li><span class="icon icon-menu"> Menu</span></li>
-  <li><span class="icon icon-next"> Next</span></li>
-  <li><span class="icon icon-other-link"> Other link</span></li>
-  <li><span class="icon icon-referral"> Referral</span></li>
-  <li><span class="icon icon-resume"> Resume</span></li>
-  <li><span class="icon icon-settings"> Settings</span></li>
-  <li><span class="icon icon-small-arrow"> Small arrow</span></li>
-  <li><span class="icon icon--small icon-back"> Small back</span></li>
-  <li><span class="icon icon--small icon-next"> Small next</span></li>
-  <li><span class="icon icon-support"> Support</span></li>
-  <li><span class="icon icon-visa"> Visa</span></li>
+  <li><span class="icon icon-arrow"><span class="icon__label">Arrow</span></span></li>
+  <li><span class="icon icon-back"><span class="icon__label">Back</span></span></li>
+  <li><span class="icon icon-close"><span class="icon__label">Close</span></span></li>
+  <li><span class="icon icon-copy-link"><span class="icon__label">Copy link</span></span></li>
+  <li><span class="icon icon-dribble"><span class="icon__label">Dribble</span></span></li>
+  <li><span class="icon icon-filter"><span class="icon__label">Filter</span></span></li>
+  <li><span class="icon icon-github"><span class="icon__label">GitHub</span></span></li>
+  <li><span class="icon icon-linkedin"><span class="icon__label">LinkedIn</span></span></li>
+  <li><span class="icon icon-location"><span class="icon__label">Location</span></span></li>
+  <li><span class="icon icon-locked"><span class="icon__label">Locked</span></span></li>
+  <li><span class="icon icon-menu"><span class="icon__label">Menu</span></span></li>
+  <li><span class="icon icon-next"><span class="icon__label">Next</span></span></li>
+  <li><span class="icon icon-other-link"><span class="icon__label">Other link</span></span></li>
+  <li><span class="icon icon-referral"><span class="icon__label">Referral</span></span></li>
+  <li><span class="icon icon-resume"><span class="icon__label">Resume</span></span></li>
+  <li><span class="icon icon-settings"><span class="icon__label">Settings</span></span></li>
+  <li><span class="icon icon-arrow icon--small"><span class="icon__label">Small arrow</span></span></li>
+  <li><span class="icon icon--small icon-back"><span class="icon__label">Small back</span></span></li>
+  <li><span class="icon icon--small icon-next"><span class="icon__label">Small next</span></span></li>
+  <li><span class="icon icon-support"><span class="icon__label">Support</span></span></li>
+  <li><span class="icon icon-visa"><span class="icon__label">Visa</span></span></li>
 </ul>
 
 # Accessibility
@@ -32,14 +32,16 @@ To support screen readers all icons should have an appropriate label or text ass
 Icons can contain text directly, which will be shown and be the text read by the screen reader.
 
 ```html
-<span class="icon icon-github">GitHub</span>
+<span class="icon icon-github">
+  <span class="icon__label">GitHub</span>
+</span>
 ```
 
 If the icon is associated with nearby text, then <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden" target="_blank">aria-hidden</a> should be used to ensure that the screen reader will not try to read or focus on the icon element.
 
 ```html
 <span class="icon icon-github" aria-hidden="true">
-  <span>GitHub</span>
+  <span class="icon__label">GitHub</span>
 </span>
 ```
 

--- a/scss/objects/_icons.scss
+++ b/scss/objects/_icons.scss
@@ -19,17 +19,24 @@
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
     color: $default-icon-color;
-    font: normal normal normal ($base-font-size / 1) 'underdogio-icons';
-    font-size: inherit;
+    display: inline-block;
+    font: normal normal normal $icon-font-size 'underdogio-icons';
     text-rendering: auto;
+    vertical-align: middle;
   }
 }
 
+// Use to vertically align icons with accompanying text
+.icon__label {
+  display: inline-block;
+  margin-left: $icon-label-spacing;
+  vertical-align: middle;
+}
 
 // Helper to allow for the shrinking of icons
 .icon--small {
   &:before {
-    font-size: 0.75rem;
+    font-size: $icon-font-size-small;
   }
 }
 

--- a/scss/variables/_icons.scss
+++ b/scss/variables/_icons.scss
@@ -1,6 +1,10 @@
 // Icon font path
 $icon-font-path: '../fonts' !default;
 
+$icon-font-size: $beta-font-size;
+$icon-font-size-small: $base-font-size;
+$icon-label-spacing: $quarter-spacing-unit;
+
 // Icon coloring
 $default-icon-color: $purple;
 $icon-color-overrides: (


### PR DESCRIPTION
Adds an element to the `icon` object so that icons can be vertically aligned with their labels. Also slightly increases the font size of icons so that they can be more easily recognizable.

Before:

<img width="204" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/15100267/080eeaf8-153b-11e6-882d-86d38f52a0f0.png">

After:

<img width="278" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15100268/0bd62d22-153b-11e6-9c71-bdbb28fd8aa3.png">

/cc @underdogio/engineering 
