### PR TITLE
Decrease spacing between menu list items

### DIFF
--- a/scss/variables/_menu-list.scss
+++ b/scss/variables/_menu-list.scss
@@ -1,1 +1,1 @@
-$menu-list-item-spacing: $base-spacing-unit !default;
+$menu-list-item-spacing: $half-spacing-unit !default;


### PR DESCRIPTION
Tweaks spacing between menu items so they won't look so far apart. 

Examples (from Company Dashboard)

_Before_

<img width="264" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/15100419/f60d8e14-153e-11e6-97c4-67de1b2b7dad.png">

_After_

<img width="227" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15100420/f8e9d70a-153e-11e6-9a84-9075c2970e25.png">

/cc @underdogio/engineering 
