### PR TITLE
Add slab--disabled modifier

### DIFF
--- a/docs/slab.md
+++ b/docs/slab.md
@@ -2,7 +2,9 @@
 title: Slab
 ---
 
-Use to display pieces of information within a table or list. To highlight a slab add a modifier of `.slab--featured`.
+Use to display pieces of information within a table or list.
+
+To highlight a slab add a modifier of `.slab--featured`. To fade out a slab add a modifier of `.slab--disabled`.
 
 <ul>
   <li class="slab">
@@ -63,7 +65,7 @@ Use to display pieces of information within a table or list. To highlight a slab
       </div>
     </div>
   </li>
-  <li class="slab">
+  <li class="slab slab--disabled">
     <div class="row">
       <div class="slab__section col-3-large-and-up">
         <span class="slab__title">Matthew Marrone</span>
@@ -88,7 +90,7 @@ Use to display pieces of information within a table or list. To highlight a slab
         </ul>
       </div>
       <div class="slab__section col-2-large-and-up">
-        <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+        <a class="btn btn--block btn--primary btn--disabled" href="mailto:chris@underdog.io">Email</a>
       </div>
     </div>
   </li>

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -35,6 +35,7 @@
 @import 'variables/list-heading';
 @import 'variables/menu-drawer';
 @import 'variables/menu-list';
+@import 'variables/opacity';
 @import 'variables/section-divider';
 @import 'variables/sidebar';
 @import 'variables/slab';

--- a/scss/components/_slab.scss
+++ b/scss/components/_slab.scss
@@ -27,3 +27,7 @@
 .slab--featured {
   background: $slab-featured-bg;
 }
+
+.slab--disabled {
+  opacity: $opacity-faded;
+}

--- a/scss/variables/_opacity.scss
+++ b/scss/variables/_opacity.scss
@@ -1,0 +1,1 @@
+$opacity-faded: 0.5;


### PR DESCRIPTION
Adds a `.slab--disabled` modifier that fades out a Slab component.

Screenshot (the email button has a `.btn--disabled` class applied):

<img width="1474" alt="screen shot 2016-05-09 at 1 50 48 pm" src="https://cloud.githubusercontent.com/assets/6979137/15122443/2ae4cc3e-15ed-11e6-807d-8c5879f8e651.png">

/cc @underdogio/engineering 
