### PR TITLE
Tweak link styling

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -6,8 +6,19 @@ Basic `a` tag with no class.
 
 <a href="#">I am a link</a>
 
+<a href="#" disabled="true">I am a disabled link</a>
+
+You can also apply a class of `.text-link` to other tags so they can have the same styling as links.
+
+<span class="text-link" role="button">I am a button that looks like a link</span>
+
+<span class="text-link" role="button" disabled="true">I am a disabled button that looks like a link</span>
+
 ```html
 <a href="#">I am a link</a>
+<a href="#" disabled="true">I am a disabled link</a>
+<span class="text-link" role="button">I am a button that looks like a link</span>
+<span class="text-link" role="button" disabled="true">I am a disabled button that looks like a link</span>
 ```
 
 ## Navigation link

--- a/scss/base/_links.scss
+++ b/scss/base/_links.scss
@@ -1,5 +1,17 @@
 // Styling for site links, <a /> tags
-a {
+a,
+.text-link {
+  @include transition(color, text-decoration);
   color: $link-color;
   text-decoration: underline;
+
+  &:focus,
+  &:hover {
+    color: $link-hover-color;
+  }
+
+  &[disabled] {
+    color: $link-disabled-color;
+    text-decoration: none;
+  }
 }

--- a/scss/variables/_links.scss
+++ b/scss/variables/_links.scss
@@ -1,5 +1,7 @@
 // Link coloring
 $link-color: $purple;
+$link-hover-color: $green;
+$link-disabled-color: $dark-gray;
 $nav-link-color: $whitish-black;
 $nav-link-active-color: $purple;
 $nav-link-disabled-color: $dark-gray;


### PR DESCRIPTION
Adds `:hover` and `:focus` styles for links.

Also adds a `.text-link` class that allows non-anchor tags to have the same styling as links.

Screenshot:

<img width="1420" alt="screen shot 2016-05-09 at 4 28 20 pm" src="https://cloud.githubusercontent.com/assets/6979137/15127083/10913c80-1603-11e6-80f9-796d1711d73b.png">

/cc @underdogio/engineering 
