### PR TITLE
Make dropdown menu usable within header__nav

### DIFF
--- a/docs/dropdown-menu.md
+++ b/docs/dropdown-menu.md
@@ -2,23 +2,26 @@
 title: Dropdown Menu
 ---
 
-Use to display menu items in a hidden menu.
+Use to display menu items in a hidden menu. Dropdown menus are positioned absolutely, so
+they should only be used within elements that have their `position` property set to anything other than `static`.
 
-<div class="dropdown-menu">
-  <div class="dropdown-menu__wrapper">
-    <span class="list-heading">chris@underdog.io</span>
-    <div class="dropdown-menu__content">
-      <ul class="menu-list">
-        <li class="menu-list__item">
-          <a class="nav-link" href="/settings/">Settings</a>
-        </li>
-        <li class="menu-list__item">
-          <a class="nav-link" href="/support/">Support</a>
-        </li>
-        <li class="menu-list__item">
-          <a class="nav-link" href="/logout/">Log out</a>
-        </li>
-      </ul>
+<div style="position: relative; margin-bottom: 300px; width: 300px;">
+  <div class="dropdown-menu">
+    <div class="dropdown-menu__wrapper">
+      <span class="list-heading">chris@underdog.io</span>
+      <div class="dropdown-menu__content">
+        <ul class="menu-list">
+          <li class="menu-list__item">
+            <a class="nav-link" href="/settings/">Settings</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/support/">Support</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/logout/">Log out</a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/docs/header.md
+++ b/docs/header.md
@@ -10,6 +10,24 @@ To make a header sticky, apply the `.header--fixed` modifier class to it.
   <div class="header__nav">
     <div class="hidden--small"><span class="gamma push10--right">Lionel Itchy</span><span class="icon icon-arrow"></span></div>
     <div class="hidden--medium-and-up"><span class="icon icon-menu" aria-hidden="true"></span><span class="gamma"> Menu</span></div>
+    <div class="dropdown-menu">
+      <div class="dropdown-menu__wrapper">
+        <span class="list-heading">chris@underdog.io</span>
+        <div class="dropdown-menu__content">
+          <ul class="menu-list">
+            <li class="menu-list__item">
+              <a class="nav-link" href="/settings/">Settings</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/support/">Support</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/logout/">Log out</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -21,6 +39,24 @@ To make a header sticky, apply the `.header--fixed` modifier class to it.
   <div class="header__nav">
     <span>Lionel Itchy</span>
     <span class="icon icon-arrow" />
+    <div class="dropdown-menu">
+      <div class="dropdown-menu__wrapper">
+        <span class="list-heading">chris@underdog.io</span>
+        <div class="dropdown-menu__content">
+          <ul class="menu-list">
+            <li class="menu-list__item">
+              <a class="nav-link" href="/settings/">Settings</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/support/">Support</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/logout/">Log out</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 ```

--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -1,11 +1,16 @@
 // SEE: dropdown-menu.md
 .dropdown-menu {
-  max-width: 100%;
+  line-height: $base-line-height;
+  position: absolute;
   text-align: right;
+  margin-top: $dropdown-menu-triangle-size;
+  right: 0;
+  top: 50%;
   width: $dropdown-menu-width;
+  z-index: layer(dropdown-menu);
 
   &:before {
-    @include triangle($dropdown-menu-bg, 1em);
+    @include triangle($dropdown-menu-bg, $dropdown-menu-triangle-size);
     content: '';
     display: inline-block;
 

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -35,6 +35,7 @@ $header-logo-height: 55px;
   @extend .float--right;
   @extend .push25--right;
   line-height: inherit;
+  position: relative;
 }
 
 .header--fixed {

--- a/scss/variables/_dropdown-menu.scss
+++ b/scss/variables/_dropdown-menu.scss
@@ -3,4 +3,5 @@ $dropdown-menu-box-shadow: 0 2px 2px $gray-xdc;
 $dropdown-menu-border-radius: 4px;
 $dropdown-menu-bg: $gray-xf3 !default;
 $dropdown-menu-content-padding: $base-spacing-unit $base-spacing-width !default;
+$dropdown-menu-triangle-size: 1em;
 $dropdown-menu-width: 16em;

--- a/scss/variables/_layers.scss
+++ b/scss/variables/_layers.scss
@@ -1,7 +1,8 @@
 $layer: (
   base: 0,
   header: 1,
-  modals: 2
+  modals: 2,
+  dropdown-menu: 3
 );
 
 @function layer($key) {


### PR DESCRIPTION
Updates the `dropdown-menu` component to be usable within `header__nav`. It overrides the line-height of about `68px` set by `header` and positions itself absolutely so that the menu is always floating.

Dropdown menu in action within the header:

<img width="1477" alt="screen shot 2016-05-10 at 3 23 30 pm" src="https://cloud.githubusercontent.com/assets/6979137/15159649/9fd1e12c-16c3-11e6-900b-68b97116d698.png">

/cc @underdogio/engineering   
