### PR TITLE
Allow alert content to wrap

### DIFF
--- a/scss/objects/_alerts.scss
+++ b/scss/objects/_alerts.scss
@@ -23,17 +23,13 @@
 //     </a>
 //   </div>
 // ======
-$alert-height: 28px;
-$alert-padding-ends: 10px;
-
 .alert {
+  align-items: center;
   background: $alert-bg;
   color: $alert-color;
-  height: $alert-height;
-  padding-bottom: ($alert-height - $base-line-height) / 2;
-  padding-left: $alert-padding-ends;
-  padding-right: $alert-padding-ends;
-  padding-top: ($alert-height - $base-line-height) / 2;
+  display: flex;
+  justify-content: space-between;
+  padding: $alert-padding;
 }
 
 // Error state alert
@@ -54,10 +50,8 @@ $alert-padding-ends: 10px;
   border: 0;
   color: $alert-close-color;
   cursor: pointer;
-  float: right;
   padding: 0;
   position: relative;
-  right: 0;
   top: 2px;
 
   // Ensure all icons use the same color as $alert-close-color

--- a/scss/variables/_alerts.scss
+++ b/scss/variables/_alerts.scss
@@ -4,5 +4,6 @@ $alert-color: $black;
 $alert-close-color: $dark-gray;
 $alert-error-bg: $red;
 $alert-error-color: $white;
+$alert-padding: 10px;
 $alert-success-bg: $light-green;
 $alert-success-color: $black;


### PR DESCRIPTION
Updates the `alert` component to allow content to wrap if there is not enough room for all of it to fit on one line. Also tweaks the padding a bit :) 

Before:

<img width="258" alt="screen shot 2016-05-12 at 11 16 08 am" src="https://cloud.githubusercontent.com/assets/6979137/15219810/284cf256-1833-11e6-8c14-5122a542eeae.png">

After:

<img width="309" alt="screen shot 2016-05-12 at 11 15 29 am" src="https://cloud.githubusercontent.com/assets/6979137/15219814/2e60d590-1833-11e6-9af6-30a75d85f07f.png">

/cc @underdogio/engineering 
