### PR TITLE
Decrease font size of nav-links ever so slightly

### DIFF
--- a/scss/objects/_links.scss
+++ b/scss/objects/_links.scss
@@ -5,7 +5,7 @@
 
 // Navigation links (typically found in sidebars/header/etc)
 .nav-link {
-  @include font-size($gamma-font-size, false);
+  @include font-size($delta-font-size, false);
   color: $nav-link-color;
   text-decoration: none;
 
@@ -27,7 +27,7 @@
 
 // Menu links (typically found in menus and dropdowns)
 .menu-link {
-  @include font-size($gamma-font-size, false);
+  @include font-size($delta-font-size, false);
 
   color: $menu-link-color;
   text-decoration: none;

--- a/scss/variables/_font.scss
+++ b/scss/variables/_font.scss
@@ -3,6 +3,7 @@ $p-font-size: 14px;
 $alpha-font-size: 32px;
 $beta-font-size: 24px;
 $gamma-font-size: 18px;
+$delta-font-size: 16px;
 
 // Base font setup
 $base-font-size: $p-font-size;


### PR DESCRIPTION
Increasing the base font size from `13px` to `14px` increased the font size of menu and nav links a bit too much.

Before:

<img width="290" alt="screen shot 2016-05-12 at 11 24 15 am" src="https://cloud.githubusercontent.com/assets/6979137/15220102/50be8528-1834-11e6-8ed8-754a5e31b823.png">

After:

<img width="298" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15220098/4f43c410-1834-11e6-8329-faf22c72d533.png">

/cc @underdogio/engineering 
