### PR TITLE
Tweak padding of list headings

### DIFF
--- a/scss/variables/_dropdown-menu.scss
+++ b/scss/variables/_dropdown-menu.scss
@@ -2,6 +2,6 @@ $dropdown-menu-border: solid 1px $gray-xdc;
 $dropdown-menu-box-shadow: 0 2px 2px $gray-xdc;
 $dropdown-menu-border-radius: 4px;
 $dropdown-menu-bg: $gray-xf3 !default;
-$dropdown-menu-content-padding: $base-spacing-unit $base-spacing-width !default;
+$dropdown-menu-content-padding: $base-spacing-unit !default;
 $dropdown-menu-triangle-size: 1em;
 $dropdown-menu-width: 16em;

--- a/scss/variables/_list-heading.scss
+++ b/scss/variables/_list-heading.scss
@@ -1,3 +1,3 @@
 $list-heading-color: $dark-gray !default;
-$list-heading-padding: $base-spacing-width !default;
+$list-heading-padding: $half-spacing-unit $base-spacing-unit !default;
 $list-heading-border: 1px solid $gray-xdc;

--- a/scss/variables/_menu-drawer.scss
+++ b/scss/variables/_menu-drawer.scss
@@ -1,6 +1,6 @@
 $menu-drawer-width: 480px !default;
 $menu-drawer-max-width: 95% !default;
-$menu-drawer-section-padding:  $base-spacing-unit $base-spacing-width !default;
+$menu-drawer-section-padding:  $base-spacing-unit !default;
 $menu-drawer-section-spacing: $base-spacing-unit !default;
 $menu-drawer-overlay-bg: rgba($black, 0.5) !default;
 $menu-drawer-content-bg: $gray-xf3;


### PR DESCRIPTION
Tweaks padding of list headings, dropdown menu content, and menu sections.

Before:

_Dropdown menu_
<img width="304" alt="screen shot 2016-05-12 at 11 36 09 am" src="https://cloud.githubusercontent.com/assets/6979137/15220511/bd4a34de-1835-11e6-97b0-2749b1d874e7.png">

_Menu drawer_

<img width="508" alt="screen shot 2016-05-12 at 11 36 29 am" src="https://cloud.githubusercontent.com/assets/6979137/15220529/d3c08952-1835-11e6-867f-4a5d98c67f0d.png">

After:

_Dropdown menu_
<img width="295" alt="screen shot 2016-05-12 at 11 35 42 am" src="https://cloud.githubusercontent.com/assets/6979137/15220493/af677746-1835-11e6-875c-a2c823ebe638.png">

_Menu drawer_
<img width="544" alt="screen shot 2016-05-12 at 11 32 35 am" src="https://cloud.githubusercontent.com/assets/6979137/15220451/9767fdbe-1835-11e6-8040-609aa45391b1.png">

/cc @underdogio/engineering 
