### PR TITLE
Add styles for the modal component

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -1,0 +1,51 @@
+---
+title: Modal
+---
+
+Modals are for getting the user's attention to either confirm an action or to alert them of something urgent.
+
+Modals will always take up the full width and height of the page and be displayed over all other content.
+
+### Simple Modal
+
+<div style="position: relative; height: 500px">
+  <div class="modal" style="position: relative;">
+    <div class="modal__content">
+      <div class="modal__header">
+        This is a modal message. Enter the purpose of the modal here.
+        <button class="modal__close">
+          <span class="icon icon-close" aria-label="close" />
+        </button>
+      </div>
+      <form action="#">
+        <label for="modal-input" class="block-label">Input label</label>
+        <input id="modal-input" class="block-input" type="text" />
+        <div class="text--center">
+          <button class="btn btn--primary btn--block push18--bottom">Save</button>
+          <a href="#">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="modal">
+  <div class="modal__content">
+    <div class="modal__header">
+      This is a modal message. Enter the purpose of the modal here.
+      <button class="modal__close">
+        <span class="icon icon-close" aria-label="close" />
+      </button>
+    </div>
+    <form action="#">
+      <label for="modal-input" class="block-label">Input label</label>
+      <input id="modal-input" class="block-input" type="text" />
+      <div class="text--center">
+        <button class="btn btn--primary btn--block push10--bottom">Save</button>
+        <a href="#">Cancel</a>
+      </div>
+    </form>
+  </div>
+</div>
+```

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -1,3 +1,4 @@
+@import 'mixins/button-reset';
 @import 'mixins/center-content';
 @import 'mixins/media-query';
 @import 'mixins/transition';

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -13,6 +13,8 @@
 // Base variables
 // DEV: Must include `variables/font` and `variables/colors` first
 @import 'variables/font';
+@import 'variables/border-radius';
+@import 'variables/box-shadow';
 @import 'variables/colors';
 @import 'variables/borders';
 @import 'variables/layers';
@@ -36,6 +38,7 @@
 @import 'variables/list-heading';
 @import 'variables/menu-drawer';
 @import 'variables/menu-list';
+@import 'variables/modal';
 @import 'variables/opacity';
 @import 'variables/section-divider';
 @import 'variables/sidebar';

--- a/scss/components/_modal.scss
+++ b/scss/components/_modal.scss
@@ -1,0 +1,41 @@
+.modal {
+  background: $modal-background;
+  height: 100%;
+  left: 0;
+  padding: $modal-padding;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: layer(modals);
+}
+
+.modal__header {
+  @extend .push18--bottom;
+  @extend .epsilon;
+  align-items: flex-start;
+  color: $modal-header-color;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.modal__close {
+  background: 0 0;
+  border: 0;
+  cursor: pointer;
+  margin-left: $half-spacing-unit;
+  padding: 0;
+}
+
+.modal__content {
+  background: $modal-content-background;
+  box-shadow: $modal-content-box-shadow;
+  border-radius: $modal-content-border-radius;
+  left: 50%;
+  max-width: 100%;
+  padding: $double-spacing-width;
+  position: relative;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: $modal-content-width;
+}

--- a/scss/mixins/_button-reset.scss
+++ b/scss/mixins/_button-reset.scss
@@ -1,0 +1,5 @@
+// Resets default browser button styling
+@mixin button-reset {
+  background: 0;
+  border: 0;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -20,6 +20,7 @@
 @import 'components/list-heading';
 @import 'components/menu-drawer';
 @import 'components/menu-list';
+@import 'components/modal';
 @import 'components/section-divider';
 @import 'components/sidebar';
 @import 'components/slab';

--- a/scss/variables/_border-radius.scss
+++ b/scss/variables/_border-radius.scss
@@ -1,0 +1,1 @@
+$border-radius: 4px;

--- a/scss/variables/_box-shadow.scss
+++ b/scss/variables/_box-shadow.scss
@@ -1,0 +1,1 @@
+$box-shadow: 0 19px 38px 0 rgba(#000, 0.22);

--- a/scss/variables/_colors.scss
+++ b/scss/variables/_colors.scss
@@ -25,3 +25,6 @@ $visa-yellow: #E9A631; // Visa icon
 
 // Third party branding colors
 $google-red: #DC4E41; // Google sign in button
+
+// Transparent colors
+$semi-transparent: rgba($black, 0.2);

--- a/scss/variables/_layers.scss
+++ b/scss/variables/_layers.scss
@@ -1,8 +1,8 @@
 $layer: (
   base: 0,
   header: 1,
-  modals: 2,
-  dropdown-menu: 3
+  dropdown-menu: 2,  
+  modals: 3
 );
 
 @function layer($key) {

--- a/scss/variables/_modal.scss
+++ b/scss/variables/_modal.scss
@@ -1,0 +1,7 @@
+$modal-background: $semi-transparent;
+$modal-content-background: $white;
+$modal-content-border-radius: $border-radius;
+$modal-content-box-shadow: $box-shadow;
+$modal-content-width: 400px;
+$modal-header-color: $whitish-black;
+$modal-padding: $half-spacing-unit;


### PR DESCRIPTION
Adds styles for the "simple" modal component. 

Screenshots:

_Wide viewport_

<img width="1662" alt="screen shot 2016-05-13 at 10 57 43 am" src="https://cloud.githubusercontent.com/assets/6979137/15251908/98808cd8-18f9-11e6-9501-d1968137f3ac.png">

_Narrow viewport_

<img width="440" alt="screen shot 2016-05-13 at 10 57 55 am" src="https://cloud.githubusercontent.com/assets/6979137/15251911/9cb7c136-18f9-11e6-87ff-0c826789fae2.png">

/cc @underdogio/engineering 
