### PR TITLE
Add 'danger' button style

### DIFF
--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -40,6 +40,22 @@ Secondary buttons.
 <button class="btn btn--secondary btn--disabled" disabled="true">Disabled button</button>
 ```
 
+## Danger button
+
+<div class="row">
+  <div class="col-3-medium-and-up col-6-small">
+    <button class="btn btn--danger">Danger button</button>
+  </div>
+  <div class="col-3-medium-and-up col-6-small">
+    <button class="btn btn--danger btn--disabled" disabled="true">Disabled button</button>
+  </div>
+</div>
+
+```html
+<button class="btn btn--danger">Danger button</button>
+<button class="btn btn--danger btn--disabled" disabled="true">Disabled button</button>
+```
+
 ## Google sign in button
 
 <div class="row">

--- a/scss/objects/_buttons.scss
+++ b/scss/objects/_buttons.scss
@@ -94,6 +94,12 @@
   border: solid 1px $btn-secondary-border-color;
 }
 
+// For actions that potentially destructive, e.g. deleting your own account
+.btn--danger {
+  @include button-variant($btn-danger-bg, $btn-danger-color);
+  @include button-disabled($btn-danger-disabled-bg, $btn-danger-disabled-color);
+}
+
 // Google sign in button
 .btn--google {
   @include button-variant($btn-google-bg, $btn-google-color);

--- a/scss/variables/_buttons.scss
+++ b/scss/variables/_buttons.scss
@@ -5,6 +5,10 @@ $btn-block-font-size: 15px;
 $btn-block-font-weight: $font-weight-normal;
 
 // Button coloring
+$btn-danger-bg: $red;
+$btn-danger-color: $white;
+$btn-danger-disabled-bg: $gray-xdc;
+$btn-danger-disabled-color: $white;
 $btn-primary-bg: $green;
 $btn-primary-color: $white;
 $btn-primary-disabled-bg: $gray-xdc;


### PR DESCRIPTION
Adds a "danger" modifier class for buttons so we can emphasize when buttons perform destructive / undo-able actions when clicked

<img width="884" alt="screen shot 2016-05-14 at 9 20 34 pm" src="https://cloud.githubusercontent.com/assets/6979137/15271474/e16366ca-1a19-11e6-8f2b-f22026125a6a.png">

/cc @underdogio/engineering 
