### PR TITLE
Add a helper class for adding strikethroughs to elements

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,0 +1,19 @@
+---
+title: 'Helpers'
+---
+
+## Strikethrough
+
+Allows you to display a strikethrough on top of an element.
+Use in place of `text-decoration: line-through` when you want a line-through to
+span multiple elements.
+
+<span class="strikethrough">
+  Vehicula cillum illum reprehenderit! Laboriosam sapiente? Urna ullamcorper donec eleifend.
+</span>
+
+```html
+<span class="strikethrough">
+  Vehicula cillum illum reprehenderit! Laboriosam sapiente? Urna ullamcorper donec eleifend.
+</span>
+```

--- a/scss/generic/_helper.scss
+++ b/scss/generic/_helper.scss
@@ -53,3 +53,21 @@
     }
   }
 }
+
+.strikethrough {
+  position: relative;
+  z-index: 0;
+
+  &:after {
+    background: $whitish-black;
+    content: '';
+    display: block;
+    height: 2px;
+    left: 0;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 100%;
+    z-index: 1;
+  }
+}


### PR DESCRIPTION
Adds a `.strikethrough` helper class for adding strikethrough lines to elements.

<img width="1455" alt="screen shot 2016-05-16 at 12 34 56 pm" src="https://cloud.githubusercontent.com/assets/6979137/15296277/b0416354-1b62-11e6-8c4c-ce10b988f375.png">

/cc @underdogio/engineering 
