### PR TITLE
Update slab border color from xdc to xf3

### DIFF
--- a/docs/slab.md
+++ b/docs/slab.md
@@ -36,6 +36,35 @@ To highlight a slab add a modifier of `.slab--featured`. To fade out a slab add 
       </div>
     </div>
   </li>
+  <li class="slab">
+    <div class="row">
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__title">Matthew Marrone</span>
+        <span>Mobile engineer at <a href="#">Portable Technology Solutions</a></span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Desired Roles</span>
+        <span>Software engineer, Mobile developer</span>
+      </div>
+      <div class="slab__section col-3-large-and-up">
+        <span class="slab__heading">In their own words</span>
+        <span>
+          Interested in joining a small-to-medium-sized company with great teams and a good culture. I’m seeking a backend role though I’m open to other roles as well.
+        </span>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <span class="slab__heading">Links</span>
+        <ul>
+          <li>
+            <a href="#">GitHub</a>
+          </li>
+        </ul>
+      </div>
+      <div class="slab__section col-2-large-and-up">
+        <a class="btn btn--block btn--primary" href="mailto:chris@underdog.io">Email</a>
+      </div>
+    </div>
+  </li>
   <li class="slab slab--featured">
     <div class="row">
       <div class="slab__section col-3-large-and-up">

--- a/scss/variables/_slab.scss
+++ b/scss/variables/_slab.scss
@@ -1,4 +1,4 @@
-$slab-border: solid $border-width $gray-xdc;
+$slab-border: solid $border-width $gray-xf3;
 $slab-padding: $base-spacing-unit $base-spacing-width;
 $slab-section-margin: $base-spacing-unit 0;
 $slab-featured-bg: $gray-xf2;


### PR DESCRIPTION
Closes https://github.com/underdogio/company-dashboard/issues/214

Updates the border color in slabs from #DCDCDC to #F3F3F3

Before:

<img width="1440" alt="screen shot 2016-05-18 at 4 36 22 pm" src="https://cloud.githubusercontent.com/assets/6979137/15374137/dbb78f8a-1d16-11e6-9fa0-0c31d1ad1575.png">

After:

<img width="1431" alt="screen shot 2016-05-18 at 4 35 29 pm" src="https://cloud.githubusercontent.com/assets/6979137/15374141/e0880e0e-1d16-11e6-9723-dcd9e7f0caf6.png">

/cc @underdogio/engineering @cmuir 
