### PR TITLE
Decrease heading font-size

### DIFF
--- a/scss/variables/_font.scss
+++ b/scss/variables/_font.scss
@@ -1,9 +1,9 @@
 // Base sizes
 $p-font-size: 14px;
-$alpha-font-size: 32px;
-$beta-font-size: 24px;
-$gamma-font-size: 18px;
-$delta-font-size: 16px;
+$alpha-font-size: 30px;
+$beta-font-size: 20px;
+$gamma-font-size: 15px;
+$delta-font-size: 14px;
 
 // Base font setup
 $base-font-size: $p-font-size;


### PR DESCRIPTION
Closes #112.

Decreases the font size of headings back to their original values before we increased the overall font-size, as discussed in https://github.com/underdogio/underdog-styles/pull/110#issuecomment-218827694.

/cc @underdogio/engineering 
