### PR TITLE
Use all caps in sidebar title and slab headings

### DIFF
--- a/docs/typography.md
+++ b/docs/typography.md
@@ -43,3 +43,9 @@ Typography, the foundation of every design system.
 ```html
 <h3>Subheader</h3>
 ```
+
+<span class="small-heading">Small Heading</span>
+
+```html
+<span class="small-heading">Small Heading</span>
+```

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -1,3 +1,4 @@
+@import 'mixins/all-caps';
 @import 'mixins/button-reset';
 @import 'mixins/center-content';
 @import 'mixins/media-query';

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -41,5 +41,4 @@
 @import 'variables/modal';
 @import 'variables/opacity';
 @import 'variables/section-divider';
-@import 'variables/sidebar';
 @import 'variables/slab';

--- a/scss/base/_headings.scss
+++ b/scss/base/_headings.scss
@@ -6,3 +6,10 @@ h5,
 h6 {
   font-weight: $font-weight-normal;
 }
+
+.small-heading {
+  @include all-caps;
+  color: $small-heading-color;
+  font-size: $small-heading-size;
+  font-weight: $font-weight-bold;
+}

--- a/scss/components/_list-heading.scss
+++ b/scss/components/_list-heading.scss
@@ -5,6 +5,6 @@
   border-bottom: $list-heading-border;
   color: $list-heading-color;
   display: block;
-  font-weight: 500;
+  font-weight: $list-heading-font-weight;
   padding: $list-heading-padding;
 }

--- a/scss/components/_sidebar.scss
+++ b/scss/components/_sidebar.scss
@@ -13,7 +13,7 @@
 
 .sidebar__title {
   @extend .push10--bottom;
-  color: $sidebar-title-color;
+  @extend .small-heading;
 }
 
 .sidebar__nav {

--- a/scss/components/_slab.scss
+++ b/scss/components/_slab.scss
@@ -9,7 +9,7 @@
   display: block;
   // Match line-height of headings so they can line up nicely.
   line-height: $base-line-height;
-  margin-bottom: $base-spacing-unit / 2;
+  margin-bottom: $quarter-spacing-unit;
 }
 
 .slab__title {
@@ -17,7 +17,7 @@
 }
 
 .slab__heading {
-  @extend .block-label;
+  @extend .small-heading;
 }
 
 .slab__section {

--- a/scss/mixins/_all-caps.scss
+++ b/scss/mixins/_all-caps.scss
@@ -1,0 +1,4 @@
+@mixin all-caps {
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}

--- a/scss/variables/_font.scss
+++ b/scss/variables/_font.scss
@@ -1,3 +1,5 @@
+@import 'colors';
+
 // Base sizes
 $p-font-size: 14px;
 $alpha-font-size: 32px;
@@ -24,6 +26,7 @@ $h3-size: $gamma-font-size; // .gamma
 $h4-size: 18px; // .delta // default
 $h5-size: 16px; // .epsilon // default
 $h6-size: 14px; // .zeta // default
+$small-heading-size: 12px;
 
 // Set up spacing for baseline and between elements
 $base-spacing-unit: $base-line-height; // default
@@ -45,3 +48,6 @@ $th-small-font-size: 14px;
 // Font weights
 $font-weight-normal: 400;
 $font-weight-bold: 600;
+
+// Text colors
+$small-heading-color: $dark-gray;

--- a/scss/variables/_list-heading.scss
+++ b/scss/variables/_list-heading.scss
@@ -1,3 +1,4 @@
 $list-heading-color: $dark-gray !default;
+$list-heading-font-weight: $font-weight-bold;
 $list-heading-padding: $half-spacing-unit $base-spacing-unit !default;
 $list-heading-border: 1px solid $gray-xdc;

--- a/scss/variables/_sidebar.scss
+++ b/scss/variables/_sidebar.scss
@@ -1,1 +1,0 @@
-$sidebar-title-color: $dark-gray;


### PR DESCRIPTION
Updates `.sidebar__title` and `.slab__heading` to use all caps, which both classes inherit from a new `.small__heading` class.

Screenshots:

_Small heading_

<img width="1435" alt="screen shot 2016-05-18 at 4 58 41 pm" src="https://cloud.githubusercontent.com/assets/6979137/15374757/cda56202-1d19-11e6-8558-00d61c82dcd4.png">

_Sidebar_

<img width="1421" alt="screen shot 2016-05-18 at 4 59 58 pm" src="https://cloud.githubusercontent.com/assets/6979137/15374788/fa18c1a8-1d19-11e6-9cf5-28f7ca5e067b.png">

_Slab_

<img width="1449" alt="screen shot 2016-05-18 at 4 59 27 pm" src="https://cloud.githubusercontent.com/assets/6979137/15374779/ed4429d6-1d19-11e6-82c7-ed6f4048e0d2.png">

/cc @underdogio/engineering 
