### PR TITLE
Use flexbox instead of floats inside section dividers

### DIFF
--- a/scss/components/_section-divider.scss
+++ b/scss/components/_section-divider.scss
@@ -12,10 +12,12 @@
 $section-divider-height: 40px;
 
 .section-divider {
-  @extend .cf;
   @extend .push25--bottom;
+  align-items: center;
   background: $section-divider-bg;
+  display: flex;
   height: $section-divider-height;
+  justify-content: space-between;
   margin: 0;
   padding-bottom: ($section-divider-height - $base-line-height) / 2;
   padding-left: 16px;
@@ -32,13 +34,10 @@ $section-divider-height: 40px;
 }
 
 .section-divider__heading {
-  float: left;
   font-size: $gamma-font-size;
 }
 
 .section-divider__links {
-  float: right;
-
   .icon {
     padding-right: 5px;
   }


### PR DESCRIPTION
Replaces the usage of floats with flexbox inside `.section-divider` so we can center headings and links vertically.

Including screenshots, but you are probably going to have a hard time seeing any difference:

_Before_

<img width="1425" alt="screen shot 2016-05-18 at 5 12 15 pm" src="https://cloud.githubusercontent.com/assets/6979137/15375296/45997dc8-1d1c-11e6-97db-b205a440bd9d.png">

_After_

<img width="1420" alt="screen shot 2016-05-18 at 5 13 03 pm" src="https://cloud.githubusercontent.com/assets/6979137/15375294/43d509e4-1d1c-11e6-91c1-5b80c3dc376d.png">

**P.S.** I started working on this before we decreased font-sizes for headings. The difference was more pronounced when we had larger font-sizes, but it doesn't hurt to make sure things are centered exactly with flexbox.

/cc @underdogio/engineering 
