### PR TITLE
Make small-heading a block

### DIFF
--- a/scss/base/_headings.scss
+++ b/scss/base/_headings.scss
@@ -10,6 +10,8 @@ h6 {
 .small-heading {
   @include all-caps;
   color: $small-heading-color;
+  display: block;
   font-size: $small-heading-size;
   font-weight: $font-weight-bold;
+  margin-bottom: $half-spacing-unit;
 }


### PR DESCRIPTION
Makes `.small-heading` a block so we can apply top and bottom margins to it.

How these changes look in Company Dashboard:

<img width="400" alt="screen shot 2016-05-18 at 5 50 36 pm" src="https://cloud.githubusercontent.com/assets/6979137/15376213/9511455c-1d21-11e6-91e3-40135ea69d54.png">

/cc @underdogio/engineering 
