### PR TITLE
Reduce wrapper padding to 28px

### DIFF
--- a/scss/objects/_wrapper.scss
+++ b/scss/objects/_wrapper.scss
@@ -1,11 +1,7 @@
 .wrapper {
-  @include media-query-medium {
-    padding: $wrapper-medium-padding;
-  }
-
-  @include media-query-large-and-up {
-    padding: $wrapper-large-and-up-padding;
-  }
-
   padding: $wrapper-padding;
+
+  @include media-query-medium-and-up {
+    padding: $wrapper-medium-and-up-padding;
+  }
 }

--- a/scss/variables/_wrapper.scss
+++ b/scss/variables/_wrapper.scss
@@ -1,3 +1,2 @@
-$wrapper-padding: $gutter-width !default;
-$wrapper-medium-padding: $wrapper-padding * 2 !default;
-$wrapper-large-and-up-padding: $wrapper-padding * 4 !default;
+$wrapper-padding: $base-spacing-width !default;
+$wrapper-medium-and-up-padding: $double-spacing-width;


### PR DESCRIPTION
Closes https://github.com/underdogio/company-dashboard/issues/234.

Reducers `.wrapper` padding to 28px.

Screenshots are from Company Dashboard:

_Before_

<img width="1680" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/15376951/3bf892d6-1d26-11e6-877c-4668106d7265.png">

_After_

<img width="1674" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15376954/40acc338-1d26-11e6-9099-0f01cd607f70.png">

/cc @underdogio/engineering 
