### PR TITLE
Increase nav-link font-size

### DIFF
--- a/scss/objects/_links.scss
+++ b/scss/objects/_links.scss
@@ -5,7 +5,7 @@
 
 // Navigation links (typically found in sidebars/header/etc)
 .nav-link {
-  @include font-size($delta-font-size, false);
+  @include font-size($gamma-font-size, false);
   color: $nav-link-color;
   text-decoration: none;
 


### PR DESCRIPTION
Updates the font-size of `.nav-link` to 15px so it can match teh comp

Before:

<img width="208" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/15377327/eaa2b1fc-1d28-11e6-852d-91e962213676.png">

After:

<img width="268" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15377322/e6c913a0-1d28-11e6-9836-800370e28fec.png">

/cc @underdogio/engineering 
