### PR TITLE
Set button color on hover

### DIFF
--- a/scss/objects/_buttons.scss
+++ b/scss/objects/_buttons.scss
@@ -62,6 +62,7 @@
   &:focus,
   &:active {
     background: darken($background, $btn-hover-darken);
+    color: $color;
   }
 
   &:focus {


### PR DESCRIPTION
Fixes #131 

Turns out the issue was that I forgot to set the text color for buttons on hover, so buttons that are also `<a />` tags were defaulting to the default link color

Screenshot of the fixed hover style:

<img width="308" alt="screen shot 2016-05-20 at 1 48 35 pm" src="https://cloud.githubusercontent.com/assets/6979137/15436824/b5bfb5ba-1e91-11e6-8c84-50c84ed7dca5.png">
