### PR TITLE
Center icons

### DIFF
--- a/scss/objects/_icons.scss
+++ b/scss/objects/_icons.scss
@@ -8,6 +8,7 @@
 
 .icon {
   display: inline-block;
+  vertical-align: middle;
 
   // Ensure we only apply special text formats to the icons being added.
   // This is helpful when the icon contains text, e.g. `<span class="icon icon-github">GitHub</span>`


### PR DESCRIPTION
Vertically centers icons when they are adjacent to other elements that also have `display: inline-block`

Before:

<img width="152" alt="icon center - before" src="https://cloud.githubusercontent.com/assets/6979137/15523027/1b860628-21e5-11e6-8b27-7e5e5e19cacb.png">

After:

<img width="136" alt="icon center - after" src="https://cloud.githubusercontent.com/assets/6979137/15523029/22e22aaa-21e5-11e6-811b-f2631d32e481.png">

/cc @underdogio/engineering 
