### PR TITLE
Remove outline from links

### DIFF
--- a/scss/base/_links.scss
+++ b/scss/base/_links.scss
@@ -3,11 +3,13 @@ a,
 .text-link {
   @include transition(color, text-decoration);
   color: $link-color;
+  outline: 0;
   text-decoration: underline;
 
   &:focus,
   &:hover {
     color: $link-hover-color;
+    outline: 0;
   }
 
   &[disabled] {


### PR DESCRIPTION
Closes https://github.com/underdogio/company-dashboard/issues/302

Removes that pesky dotted outline from `<a />` tags 

Before:

<img width="122" alt="link outline - before" src="https://cloud.githubusercontent.com/assets/6979137/15523135/33b4c742-21e6-11e6-9149-08597fc5d89f.png">

After:

<img width="139" alt="link outline - after" src="https://cloud.githubusercontent.com/assets/6979137/15523137/377d100a-21e6-11e6-93d2-97868cb131b9.png">

/cc @underdogio/engineering 
