### PR TITLE
Give sidebar in aside layout a fixed width

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -24,6 +24,7 @@
 
 // Object variables
 @import 'variables/alerts';
+@import 'variables/aside-layout';
 @import 'variables/buttons';
 @import 'variables/forms';
 @import 'variables/grid';

--- a/scss/objects/_aside-layout.scss
+++ b/scss/objects/_aside-layout.scss
@@ -9,7 +9,7 @@
 
 .aside-layout__sidebar {
   // Don't modify the size of the sidebar
-  flex: 0 0 auto;
+  flex: 0 0 $aside-layout-sidebar-width;
 }
 
 .aside-layout__content {

--- a/scss/variables/_aside-layout.scss
+++ b/scss/variables/_aside-layout.scss
@@ -1,0 +1,2 @@
+// About 2/12 columns
+$aside-layout-sidebar-width: 16%;


### PR DESCRIPTION
Gives the sidebar within the `.aside-layout` a fixed width, instead of allowing it to change depending on the content inside of it.

Before (auto width):

<img width="1679" alt="sidebar - before" src="https://cloud.githubusercontent.com/assets/6979137/15553239/2c62a06c-228c-11e6-81dc-8f77962c8ae8.png">

After (fixed width):

<img width="1680" alt="sidebar - after" src="https://cloud.githubusercontent.com/assets/6979137/15553247/2ff9266a-228c-11e6-9389-b67118de1308.png">

/cc @underdogio/engineering 
