### PR TITLE
Add helper for setting position to relative for an element

### DIFF
--- a/scss/generic/_helper.scss
+++ b/scss/generic/_helper.scss
@@ -20,6 +20,11 @@
   opacity: $opacity-faded;
 }
 
+// Sets position:relative on an element
+.pos-rel {
+  position: relative;
+}
+
 // Define common push values
 @each $size in $push-sizes {
   // Push on all sides


### PR DESCRIPTION
Adds a `.pos-rel` helper class that can be used to set `position: relative` on an element. Useful for keeping other elements that have `position: absolute` or `position: relative` within a container.

/cc @underdogio/engineering 
