### PR TITLE
Add helper for centering icons with label on opposite side

### DIFF
--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -102,15 +102,15 @@ Block buttons.
 Buttons can contain non-text elements like icons.
 
 <button class="btn btn--secondary">
-  <span>Download</span>
-  <span class="icon icon-arrow" aria-hidden="true" />
+  <span class="icon__label icon__label--reverse">Download</span>
+  <span class="icon icon-arrow icon--small" aria-hidden="true" />
 </button>
 
 Button with icon.
 
 ```html
 <button class="btn btn--secondary">
-  <span>Download</span>
-  <span class="icon icon-arrow" aria-hidden="true" />
+  <span class="icon__label icon__label--reverse">Download</span>
+  <span class="icon icon-arrow icon--small" aria-hidden="true" />
 </button>
 ```

--- a/scss/objects/_icons.scss
+++ b/scss/objects/_icons.scss
@@ -6,6 +6,12 @@
   src: url('#{$icon-font-path}/underdogio-icons.eot'), url('#{$icon-font-path}/underdogio-icons.eot?#iefix') format('embedded-opentype'), url('#{$icon-font-path}/underdogio-icons.woff') format('woff'), url('#{$icon-font-path}/underdogio-icons.ttf') format('truetype'), url('#{$icon-font-path}/underdogio-icons.svg#underdogio-icons') format('svg');
 }
 
+.icon,
+.icon__label {
+  // Reset line-height so icons can be centered with labels
+  line-height: 1;
+}
+
 .icon {
   display: inline-block;
   vertical-align: middle;
@@ -29,6 +35,12 @@
   display: inline-block;
   margin-left: $icon-label-spacing;
   vertical-align: middle;
+}
+
+// Adds spacing to the opposite side of an icon label
+.icon__label--reverse {
+  margin-left: 0;
+  margin-right: $icon-label-spacing;
 }
 
 // Helper to allow for the shrinking of icons


### PR DESCRIPTION
Adds a modifier class `.icon-label__reverse` which adds spacing to the opposite of a label, for when an icon is to the right of a label instead of the left. 

Also updates the example for "Buttons with icons", and adds a tiny fix for vertically aligning icons with labels.

Before:

<img width="265" alt="btn-icon-before" src="https://cloud.githubusercontent.com/assets/6979137/15555488/f3243648-2296-11e6-9ca9-8a4c2519e6da.png">

After:

<img width="240" alt="btn-icon-after" src="https://cloud.githubusercontent.com/assets/6979137/15555487/f1656764-2296-11e6-9e51-1286ddc0cbfa.png">

I think I have to open up another PR for that damn arrow icon :'( 

/cc @underdogio/engineering 
