### PR TITLE
Add content-header component

### DIFF
--- a/docs/content-header.md
+++ b/docs/content-header.md
@@ -1,0 +1,19 @@
+---
+title: Content Header
+---
+
+A content header is the main header for a page with a title and a subtitle.
+You can also replace the subtitle with any other type of content, such as a
+button or a list of links.
+
+<div class="content-header">
+  <h1 class="content-header__title">The title</h1>
+  <button class="content-header__subtitle btn btn--secondary">Do something</button>
+</div>
+
+```html
+<div class="content-header">
+  <h1 class="content-header__title">The title</h1>
+  <button class="content-header__subtitle btn btn--secondary">Do something</button>
+</div>
+```

--- a/scss/components/_content-header.scss
+++ b/scss/components/_content-header.scss
@@ -1,0 +1,12 @@
+.content-header {
+  align-items: baseline;
+  display: flex;
+  justify-content: space-between;
+}
+
+.content-header__title,
+.content-header__subtitle {
+  // Normalize line height so headings and subtitles can align vertically
+  line-height: 1;
+  margin-bottom: 0;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -15,6 +15,7 @@
 @import 'objects/wrapper';
 
 // Underdog specific components
+@import 'components/content-header';
 @import 'components/dropdown-menu';
 @import 'components/header';
 @import 'components/list-heading';


### PR DESCRIPTION
Adds a `.content-header` component, which is just a nicely formatted title and subtitle for a page

<img width="1449" alt="screen shot 2016-05-26 at 11 23 27 am" src="https://cloud.githubusercontent.com/assets/6979137/15579846/62dbe7cc-2334-11e6-96a4-02cf1a7d9b17.png">

/cc @underdogio/engineering 
