### PR TITLE
Add btn-menu component

### DIFF
--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -114,3 +114,62 @@ Button with icon.
   <span class="icon icon-arrow icon--small" aria-hidden="true" />
 </button>
 ```
+
+## Button with dropdown
+
+Buttons can contain dropdown menus.
+
+<div style="height: 300px; padding-left: 100px;">
+  <div class="btn-menu">
+    <button class="btn btn--secondary">
+      <span class="icon__label icon__label--reverse">Download</span>
+      <span class="icon icon-arrow icon--small" aria-hidden="true" />
+    </button>
+    <div class="dropdown-menu">
+      <div class="dropdown-menu__wrapper">
+        <span class="list-heading">chris@underdog.io</span>
+        <div class="dropdown-menu__content">
+          <ul class="menu-list">
+            <li class="menu-list__item">
+              <a class="nav-link" href="/settings/">Settings</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/support/">Support</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/logout/">Log out</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+```html
+<span class="btn-menu">
+  <button class="btn btn--secondary">
+    <span class="icon__label icon__label--reverse">Download</span>
+    <span class="icon icon-arrow icon--small" aria-hidden="true" />
+  </button>
+
+  <div class="dropdown-menu">
+    <div class="dropdown-menu__wrapper">
+      <span class="list-heading">chris@underdog.io</span>
+      <div class="dropdown-menu__content">
+        <ul class="menu-list">
+          <li class="menu-list__item">
+            <a class="nav-link" href="/settings/">Settings</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/support/">Support</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/logout/">Log out</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</span>
+```

--- a/scss/components/_btn-menu.scss
+++ b/scss/components/_btn-menu.scss
@@ -1,0 +1,5 @@
+// SEE: buttons.md
+.btn-menu {
+  @extend .pos-rel;
+  display: inline-block;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -15,6 +15,7 @@
 @import 'objects/wrapper';
 
 // Underdog specific components
+@import 'components/btn-menu';
 @import 'components/content-header';
 @import 'components/dropdown-menu';
 @import 'components/header';


### PR DESCRIPTION
Adds a `.btn-menu` component, which allows for a `.btn` and `.dropdown-menu` to be used together.

<img width="1483" alt="screen shot 2016-05-26 at 11 17 48 am" src="https://cloud.githubusercontent.com/assets/6979137/15579874/8596a2b6-2334-11e6-9ef2-74072a417eb6.png">

/cc @underdogio/engineering 
