### PR TITLE
Fix content header alignment

### DIFF
--- a/scss/components/_content-header.scss
+++ b/scss/components/_content-header.scss
@@ -1,5 +1,5 @@
 .content-header {
-  align-items: baseline;
+  align-items: flex-end;
   display: flex;
   justify-content: space-between;
 }


### PR DESCRIPTION
Fixes an alignment of title and subtitle within `.content-header`

Before:

<img width="1421" alt="content-header-before" src="https://cloud.githubusercontent.com/assets/6979137/15581008/c5f03620-2338-11e6-94be-4a00c584befb.png">

After:

<img width="1443" alt="content-header-after" src="https://cloud.githubusercontent.com/assets/6979137/15581002/bfe555d0-2338-11e6-95eb-55113ba374c4.png">

/cc @underdogio/engineering 
