### PR TITLE
Add helper for preserving newlines in whitespace

### DIFF
--- a/scss/generic/_helper.scss
+++ b/scss/generic/_helper.scss
@@ -64,6 +64,12 @@
   }
 }
 
+// Preserves new lines
+// SEE: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
+.white-space--pre-line {
+  white-space: pre-line;
+}
+
 .strikethrough {
   position: relative;
   z-index: 0;


### PR DESCRIPTION
Adds a helper for preserving newlines in whitespace.

For more info on the `white-space` CSS property see https://developer.mozilla.org/en-US/docs/Web/CSS/white-space.

/cc @underdogio/engineering 
