### PR TITLE
Add fader object for transitioning opacity

### DIFF
--- a/scss/objects/_fader.scss
+++ b/scss/objects/_fader.scss
@@ -1,0 +1,8 @@
+// Use to transition an element's opacity
+.fader {
+  @include transition(opacity);
+}
+
+.fader--faded {
+  opacity: $opacity-faded;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -8,6 +8,7 @@
 @import 'objects/buttons';
 @import 'objects/container';
 @import 'objects/divider';
+@import 'objects/fader';
 @import 'objects/grid';
 @import 'objects/icons';
 @import 'objects/links';


### PR DESCRIPTION
Adds a `.fader` object that can be used to fade an element's `opacity`.

Related to https://github.com/underdogio/company-dashboard/issues/290 and https://github.com/underdogio/company-dashboard/issues/336

/cc @underdogio/engineering 
