### PR TITLE
Prepare for release on Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,13 @@
   "description": "Organization wide styles",
   "ignore": [
     "**/.*",
-    "bower_components"
+    "bin",
+    "bower_components",
+    "docs",
+    "node_modules",
+    "Procfile",
+    "server",
+    "test"
   ],
   "dependencies": {
     "inuit.css": "5.0.1"


### PR DESCRIPTION
Prepares `underdog-styles` for release on Bower by ignoring files that aren't necessary for publishing.

/cc @underdogio/engineering 
