### PR TITLE
Remove bottom margin from section divider headings

### DIFF
--- a/scss/components/_section-divider.scss
+++ b/scss/components/_section-divider.scss
@@ -35,6 +35,7 @@ $section-divider-height: 40px;
 
 .section-divider__heading {
   font-size: $gamma-font-size;
+  margin-bottom: 0;
 }
 
 .section-divider__links {


### PR DESCRIPTION
Fixes the heading for the table of contents by removing the bottom margin from `.section-divider__heading`

Before:

<img width="341" alt="screen shot 2016-06-02 at 11 19 37 am" src="https://cloud.githubusercontent.com/assets/6979137/15750328/0594b910-28b4-11e6-9c4b-bfaae8567514.png">

After:

<img width="340" alt="screen shot 2016-06-02 at 11 19 46 am" src="https://cloud.githubusercontent.com/assets/6979137/15750323/01d030e8-28b4-11e6-9dbf-ab2e544a24f9.png">

/cc @underdogio/engineering 
