### PR TITLE
Add hero object

### DIFF
--- a/docs/hero.md
+++ b/docs/hero.md
@@ -1,0 +1,62 @@
+---
+title: Hero
+---
+
+Heros are used to summarize the main objective of a page or website. They should always
+be the first element in a page, and there should never be more than one hero on a single page.
+
+`.hero` uses flexbox to center content, so all content must be contained within a single node.
+
+### Default hero
+
+<div class="hero">
+  <div>
+    <h1 class="push18--bottom">Apply to top startup jobs in 60 seconds</h1>
+    <p class="gamma push25--bottom">We connect candidates with awesome New York, San Francisco, and remote companies</p>
+    <div>
+      <a class="btn btn--secondary push18--right" href="#hero">Candidates</a>
+      <a class="btn btn--secondary push18--left" href="#hero">Startups</a>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="hero">
+  <div>
+    <h1 class="push18--bottom">Apply to top startup jobs in 60 seconds</h1>
+    <p class="gamma push25--bottom">We connect candidates with awesome New York, San Francisco, and remote companies</p>
+    <div>
+      <a class="btn btn--secondary push18--right" href="#hero">Candidates</a>
+      <a class="btn btn--secondary push18--left" href="#hero">Startups</a>
+    </div>
+  </div>
+</div>
+```
+
+### Large hero
+
+Use the `.hero--large` modifier to get a larger hero that will scale to take up a majority of the viewport height.
+
+<div class="hero hero--large">
+  <div>
+    <h1 class="push18--bottom">Apply to top startup jobs in 60 seconds</h1>
+    <p class="gamma push25--bottom">We connect candidates with awesome New York, San Francisco, and remote companies</p>
+    <div>
+      <a class="btn btn--secondary push18--right" href="#hero">Candidates</a>
+      <a class="btn btn--secondary push18--left" href="#hero">Startups</a>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="hero--large">
+  <div>
+    <h1 class="push18--bottom">Apply to top startup jobs in 60 seconds</h1>
+    <p class="gamma push25--bottom">We connect candidates with awesome New York, San Francisco, and remote companies</p>
+    <div>
+      <a class="btn btn--secondary push18--right" href="#hero">Candidates</a>
+      <a class="btn btn--secondary push18--left" href="#hero">Startups</a>
+    </div>
+  </div>
+</div>
+```

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -28,6 +28,7 @@
 @import 'variables/buttons';
 @import 'variables/forms';
 @import 'variables/grid';
+@import 'variables/hero';
 @import 'variables/icons';
 @import 'variables/links';
 @import 'variables/section';

--- a/scss/objects/_hero.scss
+++ b/scss/objects/_hero.scss
@@ -1,0 +1,26 @@
+// SEE: hero.md
+.hero {
+  align-items: center;
+  background: $hero-bg;
+  color: $hero-color;
+  display: flex;
+  justify-content: center;
+  padding: $hero-padding;
+  text-align: center;
+
+  a:not(.btn) {
+    // Make links visible
+    // DEV: By default links have the same color as the hero background
+    color: inherit;
+
+    &:focus,
+    &:hover {
+      color: $link-hover-color;
+    }
+  }
+}
+
+.hero--large {
+  height: $hero-large-height;
+  min-height: $hero-large-min-height;
+}

--- a/scss/underdog.scss
+++ b/scss/underdog.scss
@@ -10,6 +10,7 @@
 @import 'objects/divider';
 @import 'objects/fader';
 @import 'objects/grid';
+@import 'objects/hero';
 @import 'objects/icons';
 @import 'objects/links';
 @import 'objects/section';

--- a/scss/variables/_hero.scss
+++ b/scss/variables/_hero.scss
@@ -1,0 +1,6 @@
+$hero-bg: $purple;
+$hero-color: $white;
+$hero-padding: ($base-spacing-unit * 4) $base-spacing-width;
+
+$hero-large-min-height: 320px;
+$hero-large-height: 80vh;

--- a/server/views/index.hbs
+++ b/server/views/index.hbs
@@ -1,12 +1,23 @@
-<div class="container">
+<div>
   <header>
-    <h1>Underdog.io UI tool kit</h1>
-
-    <div id="toc" class="section-divider">
-      <h2 class="section-divider__heading">Table of Contents</h2>
+    <div class="hero hero--large">
+      <div>
+        <h1 class="push18--bottom">Underdog.io Styleguide</h1>
+        <p class="gamma push25--bottom">
+          The design system for Underdog.io
+        </p>
+        <a class="btn btn--secondary" href="https://github.com/underdogio/underdog-styles" target="_blank">
+          <span class="icon__label icon__label--reverse">View on GitHub</span>
+          <span class="icon icon-github" aria-hidden="true" />
+        </a>
+      </div>
     </div>
 
     <div class="container">
+      <div id="toc" class="section-divider">
+        <h2 class="section-divider__heading">Table of Contents</h2>
+      </div>
+
       <ul>
         {{#each sections }}
           <li>
@@ -16,7 +27,7 @@
       </ul>
     </div>
   </header>
-  <main>
+  <main class="container">
     {{#each sections }}
       <section id="{{ slug }}">
         <div class="section-divider">


### PR DESCRIPTION
Adds a `.hero` object. Also adds an intro `.hero` to the styleguide.

Default hero:

<img width="1680" alt="hero-default" src="https://cloud.githubusercontent.com/assets/6979137/15753749/c753abf2-28c2-11e6-9a4c-31d9416467e7.png">

Large hero:

<img width="1679" alt="hero-large" src="https://cloud.githubusercontent.com/assets/6979137/15753752/cadc9c52-28c2-11e6-9898-a941bd7171e5.png">

The intro hero in the styleguide would look better if our logo was in there, but we don't have an image for our logo in the styleguide, so I'll add that in another PR.

/cc @underdogio/engineering 
