### PR TITLE
Unmark bower package as private

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,5 @@
   "dependencies": {
     "inuit.css": "5.0.1"
   },
-  "main": "scss/style.scss",
-  "private": true
+  "main": "scss/style.scss"
 }


### PR DESCRIPTION
Removes the `private` flag from `bower.json` so we can publish on Bower :p

/cc @underdogio/engineering 