### PR TITLE
Use flexbox in header

### DIFF
--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -11,30 +11,24 @@
 // </div>
 // ======
 
-$header-height: 68px;
-$header-logo-height: 55px;
-
 .header {
-  @extend .cf;
+  align-items: center;
   background: $header-bg;
   color: $header-color;
-  line-height: $header-height;
+  display: flex;
+  justify-content: space-between;
+  padding: $header-padding;
 }
 
 .header__logo {
-  @extend .float--left;
   @extend .push25--left;
-  $vertical-margin: ($header-height - $header-logo-height) / 2;
-
-  height: $header-logo-height;
-  margin-bottom: $vertical-margin;
-  margin-top: $vertical-margin;
+  // Hack for removing extra spacing around <img /> tags
+  // SEE: https://css-tricks.com/fighting-the-space-between-inline-block-elements/
+  display: flex;
 }
 
 .header__nav {
-  @extend .float--right;
   @extend .push25--right;
-  line-height: inherit;
   position: relative;
 }
 

--- a/scss/variables/_header.scss
+++ b/scss/variables/_header.scss
@@ -1,3 +1,4 @@
 // Header coloring
 $header-bg: $white;
 $header-color: $whitish-black;
+$header-padding: $quarter-spacing-unit 0;


### PR DESCRIPTION
Replaces the usage of floats with flexbox. This will allow us to change the sizing of the logo independently of the header.

No visual changes, but including screenshots because why not:

*Before*:

<img width="1420" alt="header-before" src="https://cloud.githubusercontent.com/assets/6979137/15789337/8dfd87d8-2999-11e6-91b1-e74d49161aeb.png">

*After*:

<img width="1420" alt="header-after" src="https://cloud.githubusercontent.com/assets/6979137/15789331/88b9f5fe-2999-11e6-80f2-fe7c9295c8e5.png">

/cc @underdogio/engineering 