### PR TITLE
Decrease size of spinner

### DIFF
--- a/scss/variables/_spinner.scss
+++ b/scss/variables/_spinner.scss
@@ -12,10 +12,10 @@
 
 $spinner-color: $whitish-black;
 
-$spinner-size: 100px;
+$spinner-size: 25px;
 $spinner-speed: 0.75s;
-$spinner-width: 5px;
+$spinner-width: 3px;
 
-$spinner-small-size: 25px;
+$spinner-small-size: 15px;
 $spinner-small-speed: 0.5s;
 $spinner-small-width: 2px;


### PR DESCRIPTION
Decreases the size of the spinner so it won't be so massive.

*Before*:

<img width="297" alt="screen shot 2016-06-06 at 11 23 59 am" src="https://cloud.githubusercontent.com/assets/6979137/15827453/32530fd8-2bd9-11e6-97f1-cd38501821da.png">

*After*: 

<img width="294" alt="screen shot 2016-06-06 at 11 23 21 am" src="https://cloud.githubusercontent.com/assets/6979137/15827443/25ca858e-2bd9-11e6-9b94-871b0f0555c0.png">

/cc @underdogio/engineering 