### PR TITLE
Remove version field from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "underdog-styles",
-  "version": "1.0.0",
   "homepage": "https://github.com/underdogio/underdog-styles",
   "description": "Organization wide styles",
   "ignore": [


### PR DESCRIPTION
Bower ignores the `version` field, so we should remove it.

/cc @underdogio/engineering 