### PR TITLE
Let icons inherit their color property

### DIFF
--- a/scss/objects/_icons.scss
+++ b/scss/objects/_icons.scss
@@ -22,7 +22,6 @@
   &:before {
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
-    color: $default-icon-color;
     display: inline-block;
     font: normal normal normal $icon-font-size 'underdogio-icons';
     text-rendering: auto;

--- a/scss/variables/_icons.scss
+++ b/scss/variables/_icons.scss
@@ -6,17 +6,18 @@ $icon-font-size-small: $base-font-size;
 $icon-label-spacing: $quarter-spacing-unit;
 
 // Icon coloring
-$default-icon-color: $purple;
 $icon-color-overrides: (
-  arrow: $whitish-black,
-  close: $whitish-black,
   dribble: $dribble-pink,
   github: $black,
+  location: $purple,
   linkedin: $linkedin-blue,
-  locked: $whitish-black,
+  menu: $purple,
+  other-link: $purple,
   referral: $blue,
   resume: $light-red,
+  settings: $purple,
   small-arrow: $gray-xdc,
+  support: $purple,
   visa: $visa-yellow,
 );
 


### PR DESCRIPTION
Removes the default purple color from icons so their colors can be changed with a class, e.g. `color--red`.

Overrides were added for icons that should always be purple.

/cc @underdogio/engineering 