### PR TITLE
Use semi-transparent blue for slab backgrounds

### DIFF
--- a/scss/variables/_colors.scss
+++ b/scss/variables/_colors.scss
@@ -28,3 +28,4 @@ $google-red: #DC4E41; // Google sign in button
 
 // Transparent colors
 $semi-transparent: rgba($black, 0.2);
+$semi-transparent-blue: rgba($blue, 0.05);

--- a/scss/variables/_slab.scss
+++ b/scss/variables/_slab.scss
@@ -1,4 +1,4 @@
 $slab-border: solid $border-width $gray-xf3;
 $slab-padding: $base-spacing-unit $base-spacing-width;
 $slab-section-margin: $base-spacing-unit 0;
-$slab-featured-bg: $gray-xf2;
+$slab-featured-bg: $semi-transparent-blue;


### PR DESCRIPTION
Updates "featured" slabs to have a semi-transparent blue background instead of gray.

*Before*

<img width="1152" alt="screen shot 2016-06-07 at 2 21 16 pm" src="https://cloud.githubusercontent.com/assets/6979137/15869608/21929c44-2cbb-11e6-8a15-a4fffe414c4c.png">

*After*

<img width="1421" alt="screen shot 2016-06-07 at 2 16 01 pm" src="https://cloud.githubusercontent.com/assets/6979137/15869593/10af6b5a-2cbb-11e6-8c2f-f18171757a79.png">

/cc @underdogio/engineering 