### PR TITLE
Set text color for disabled slabs instead of setting opacity

### DIFF
--- a/scss/components/_slab.scss
+++ b/scss/components/_slab.scss
@@ -29,5 +29,19 @@
 }
 
 .slab--disabled {
-  opacity: $opacity-faded;
+  // Set color instead of opacity so that icons won't be faded out
+  color: $slab-disabled-color;
+
+  .slab__heading {
+    color: $slab-disabled-color;
+  }
+
+  a {
+    color: inherit;
+
+    &:hover {
+      // Don't override hover styles
+      color: initial;
+    }
+  }
 }

--- a/scss/variables/_slab.scss
+++ b/scss/variables/_slab.scss
@@ -1,4 +1,5 @@
 $slab-border: solid $border-width $gray-xf3;
+$slab-disabled-color: $semi-transparent;
 $slab-padding: $base-spacing-unit $base-spacing-width;
 $slab-section-margin: $base-spacing-unit 0;
 $slab-featured-bg: $gray-xf2;


### PR DESCRIPTION
Updates "disabled" slabs (`.slab--disabled`) to use a semi-transparent text color instead of fading out the entire slab. 

This will allow us to include elements, like icons, without having them being faded out.

*Before*

<img width="1147" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/15870184/6beeea16-2cbd-11e6-8464-ede95e362dd3.png">

*After*

<img width="1141" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15870271/b8496242-2cbd-11e6-9a2b-9a00a2428482.png">

/cc @underdogio/engineering 