### PR TITLE
Fade icons in disabled slabs

### DIFF
--- a/scss/components/_slab.scss
+++ b/scss/components/_slab.scss
@@ -32,8 +32,9 @@
   // Set color instead of opacity so that icons won't be faded out
   color: $slab-disabled-color;
 
-  .slab__heading {
-    color: $slab-disabled-color;
+  .slab__heading,
+  .icon:before {
+    color: inherit;
   }
 
   a {


### PR DESCRIPTION
We actually want to fade out icons in disabled slabs. Icons that have an explicit color set will not be overridden.

*Before*

<img width="1153" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/15870702/2849f768-2cbf-11e6-8d02-728964810332.png">

*After*

<img width="1144" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/15870707/2b2bde7e-2cbf-11e6-85fd-9007df55e228.png">

/cc @underdogio/engineering 