### PR TITLE
Center alert close icon with message

### DIFF
--- a/scss/objects/_alerts.scss
+++ b/scss/objects/_alerts.scss
@@ -29,6 +29,8 @@
   color: $alert-color;
   display: flex;
   justify-content: space-between;
+  // Reset line-height so children will align correctly
+  line-height: 1;
   padding: $alert-padding;
 }
 
@@ -50,9 +52,9 @@
   border: 0;
   color: $alert-close-color;
   cursor: pointer;
+  // Reset line-height so icon can align with accompanying text
+  line-height: inherit;
   padding: 0;
-  position: relative;
-  top: 2px;
 
   // Ensure all icons use the same color as $alert-close-color
   .icon {


### PR DESCRIPTION
Closes #159 

Fixes alignment of alert messages with close buttons.

*Before*

<img width="1132" alt="alert-before" src="https://cloud.githubusercontent.com/assets/6979137/16019537/79290946-3177-11e6-9882-5033850a6c2c.png">

*After*

<img width="1135" alt="alert-after" src="https://cloud.githubusercontent.com/assets/6979137/16019539/7c1a2b12-3177-11e6-89b3-e9bbe39fcf96.png">

/cc @underdogio/engineering 