### PR TITLE
Update form examples to wrap input tags with a label tag

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -8,36 +8,48 @@ title: Forms
 
 <div class="row">
   <div class="col-12">
-    <label class="block-label">Full width input</label>
-    <input class="block-input" type="text" />
+    <label>
+      <span class="block-label">Full width input</span>
+      <input class="block-input" type="text" />
+    </label>
   </div>
 </div>
 <div class="row">
   <div class="col-6">
-    <label class="block-label">First half</label>
-    <input class="block-input" type="email" />
+    <label>
+      <span class="block-label">First half</span>
+      <input class="block-input" type="email" />
+    </label>
   </div>
   <div class="col-6">
-    <label class="block-label">Second half</label>
-    <input class="block-input" type="password" />
+    <label>
+      <span class="block-label">Second half</span>
+      <input class="block-input" type="password" />
+    </label>
   </div>
 </div>
 
 ```html
 <div class="row">
   <div class="col-12">
-    <label class="block-label">Full width input</label>
-    <input class="block-input" type="text" />
+    <label>
+      <span class="block-label">Full width input</span>
+      <input class="block-input" type="text" />
+    </label>
   </div>
 </div>
 <div class="row">
   <div class="col-6">
-    <label class="block-label">First half</label>
-    <input class="block-input" type="email" />
+    <label>
+      <span class="block-label">First half</span>
+      <input class="block-input" type="email" />
+    </label>
   </div>
   <div class="col-6">
-    <label class="block-label">Second half</label>
-    <input class="block-input" type="password" />
+    <label>
+      <span class="block-label">Second half</span>
+      <input class="block-input" type="password" />
+    </label>
   </div>
 </div>
 ```
@@ -46,24 +58,30 @@ title: Forms
 
 To disabled a text input you can set the property `disabled="true"`.
 
-<label class="block-label">Disabled</label>
-
-<input class="block-input" type="text" disabled="true" />
+<label>
+  <span class="block-label">Disabled</span>
+  <input class="block-input" type="text" disabled="true" />
+</label>
 
 ```html
-<label class="block-label">Disabled</label>
-<input class="block-input" type="text" disabled="true" />
+<label>
+  <span class="block-label">Disabled</span>
+  <input class="block-input" type="text" disabled="true" />
+</label>
 ```
 
 ## Text input with error
 
-<label class="block-label block-label--error">Error</label>
-
-<input class="block-input input--error" type="text" />
+<label>
+  <span class="block-label block-label--error">Error</span>
+  <input class="block-input input--error" type="text" />
+</label>
 
 ```html
-<label class="block-label block-label--error">Error</label>
-<input class="block-input input--error" type="text" />
+<label>
+  <span class="block-label block-label--error">Error</span>
+  <input class="block-input input--error" type="text" />
+</label>
 ```
 
 ## Submit button

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -18,8 +18,10 @@ Modals will always take up the full width and height of the page and be displaye
         </button>
       </div>
       <form action="#">
-        <label for="modal-input" class="block-label">Input label</label>
-        <input id="modal-input" class="block-input" type="text" />
+        <label>
+          <span class="block-label">Input label</span>
+          <input class="block-input" type="text" />
+        </label>
         <div class="text--center">
           <button class="btn btn--primary btn--block push18--bottom">Save</button>
           <a href="#">Cancel</a>
@@ -39,8 +41,10 @@ Modals will always take up the full width and height of the page and be displaye
       </button>
     </div>
     <form action="#">
-      <label for="modal-input" class="block-label">Input label</label>
-      <input id="modal-input" class="block-input" type="text" />
+      <label>
+        <span class="block-label">Input label</span>
+        <input class="block-input" type="text" />
+      </label>
       <div class="text--center">
         <button class="btn btn--primary btn--block push10--bottom">Save</button>
         <a href="#">Cancel</a>


### PR DESCRIPTION
Closes #174

Updates form input examples to use our preferred style of wrapping input tags in a `<label />` element.

/cc @underdogio/engineering 