### PR TITLE
Add link to underdog.io in header

### DIFF
--- a/server/views/styleguide.hbs
+++ b/server/views/styleguide.hbs
@@ -5,6 +5,9 @@
         <img class="hidden--small" src="/dist/img/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
         <img class="hidden--medium-and-up" src="/dist/img/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
       </a>
+      <a class="header__nav" href="https://underdog.io">
+        Go to Underdog.io
+      </a>
     </div>
   </div>
   <div class="app-container__content container">


### PR DESCRIPTION
Adds a link to https://underdog.io in the header.

<img width="1680" alt="screen shot 2016-06-14 at 5 22 41 pm" src="https://cloud.githubusercontent.com/assets/6979137/16060209/a0201be2-3254-11e6-8d04-8bd01cab4adc.png">

/cc @underdogio/engineering 