### PR TITLE
Set purple color to 59518b

### DIFF
--- a/scss/underdog/variables/_colors.scss
+++ b/scss/underdog/variables/_colors.scss
@@ -16,7 +16,7 @@ $orange: #E9A631; // Sunshine
 $green: #72CEAA; // Barf
 $light-green: #ECF6F2; // Playtime
 $blue: #3497FF; // Good boy blue
-$purple: #524B7A; // Pupple
+$purple: #59518b; // Pupple
 
 // Custom icon colors
 $dribble-pink: #EB4C89; // Dribble icon


### PR DESCRIPTION
Closes #180 

Slight tweak to the `$purple` color.

*Old*

<img width="240" alt="screen shot 2016-06-16 at 5 57 17 pm" src="https://cloud.githubusercontent.com/assets/6979137/16134553/cc792858-33eb-11e6-8439-0439db0dd7b1.png">

*New*

<img width="253" alt="screen shot 2016-06-16 at 5 56 38 pm" src="https://cloud.githubusercontent.com/assets/6979137/16134544/b9baf0f2-33eb-11e6-984a-c8263eef04c0.png">


/cc @underdogio/engineering 