### PR TITLE
Make hero background green

### DIFF
--- a/scss/underdog/variables/_hero.scss
+++ b/scss/underdog/variables/_hero.scss
@@ -1,4 +1,4 @@
-$hero-bg: $purple;
+$hero-bg: $green;
 $hero-color: $white;
 $hero-padding: ($base-spacing-unit * 4) $base-spacing-width;
 


### PR DESCRIPTION
Updates the hero background color to be green instead of purple.

*Before*

<img width="1156" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16164894/a9c86918-34ae-11e6-80f0-22c46bf050e6.png">

*After*

<img width="1166" alt="hero" src="https://cloud.githubusercontent.com/assets/6979137/16164899/b1146690-34ae-11e6-803c-c4d0e86fd8bc.png">

/cc @underdogio/engineering 