### PR TITLE
Add modifier to center grid columns vertically

### DIFF
--- a/docs/grids.md
+++ b/docs/grids.md
@@ -100,6 +100,35 @@ We use a nestable fluid 12 column grid system which supports our custom breakpoi
   </div>
 </div>
 
+## Flexbox grid
+
+Columns can be centered vertically by applying the `.row--flex` modifier to a `.row`.
+
+<div class="text--center">
+  <div class="row row--flex">
+    <div class="col-3">
+      <p class="greybox flush--bottom">One third</p>
+    </div>
+    <div class="col-6">
+      <img alt="Underdog.io logo" src="/dist/img/underdogio-logo.svg" />
+    </div>
+    <div class="col-3">
+      <p class="greybox flush--bottom">One third</p>
+    </div>
+  </div>
+  <div class="row row--flex text--center">
+    <div class="col-4">
+      <p class="greybox flush--bottom">One fourth</p>
+    </div>
+    <div class="col-6">
+      <p class="greybox flush--bottom">One half</p>
+    </div>
+    <div class="col-2">
+      <img alt="Underdog.io logo" src="/dist/img/underdogio-logo.svg" />
+    </div>
+  </div>
+</div>
+
 ## Column offsets
 
 Just like our normal columns we can offset using the <code>.offset-{column}</code> or <code>.offset-{column}-{media-query}</code> class names.

--- a/scss/underdog/objects/_grid.scss
+++ b/scss/underdog/objects/_grid.scss
@@ -52,6 +52,18 @@
   margin-right: -($gutter-width / 2);
 }
 
+.row--flex {
+  align-items: center;
+  display: flex;
+
+  // Don't float columns
+  [class*=col-] {
+    // Allow width property to work for columns
+    flex: 0 0 auto;
+    float: none;
+  }
+}
+
 // Column helper
 @mixin row-column($column) {
   padding-left: ($gutter-width / 2);


### PR DESCRIPTION
Adds a `.row--flex` modifier for the `.row` object that allows columns to be centered vertically.

<img width="1120" alt="row-flex-zone" src="https://cloud.githubusercontent.com/assets/6979137/16205643/bbccfdcc-36f2-11e6-9a18-e16a3d4309f3.png">

/cc @underdogio/engineering 