### PR TITLE
Use lighter color for subheaders

### DIFF
--- a/scss/underdog/base/_forms.scss
+++ b/scss/underdog/base/_forms.scss
@@ -78,7 +78,6 @@ input {
   color: $block-label-color;
   display: block;
   font-size: $block-label-font-size;
-  font-weight: $block-label-font-weight;
   margin-bottom: $block-label-margin;
   width: 100%;
 }

--- a/scss/underdog/base/_headings.scss
+++ b/scss/underdog/base/_headings.scss
@@ -4,7 +4,12 @@ h3,
 h4,
 h5,
 h6 {
+  color: $subheader-color;
   font-weight: $font-weight-normal;
+}
+
+h1 {
+  color: $headline-color;
 }
 
 .small-heading {

--- a/scss/underdog/objects/_hero.scss
+++ b/scss/underdog/objects/_hero.scss
@@ -8,6 +8,11 @@
   padding: $hero-padding;
   text-align: center;
 
+  h1, h2, h3, h4, h5, h6 {
+    // Remove default dark text color from headings
+    color: inherit;
+  }
+
   a:not(.btn) {
     // Make links visible
     // DEV: By default links have the same color as the hero background

--- a/scss/underdog/variables/_alerts.scss
+++ b/scss/underdog/variables/_alerts.scss
@@ -1,7 +1,7 @@
 // Alert coloring
 $alert-bg: $gray-xf3;
 $alert-color: $black;
-$alert-close-color: $dark-gray;
+$alert-close-color: $light-purple;
 $alert-error-bg: $red;
 $alert-error-color: $white;
 $alert-padding: 10px;

--- a/scss/underdog/variables/_colors.scss
+++ b/scss/underdog/variables/_colors.scss
@@ -3,7 +3,8 @@
 // Grayscale from black to white
 $black: #000000;
 $whitish-black: #0B1D2B; // Bedtime
-$dark-gray: #908E9E; // Wag
+$light-gray: #777777;
+$dark-gray: #444444;
 $gray-xdc: #DCDCDC; // Sit
 $gray-xf3: #F3F3F3; // Stay
 $gray-xf2: #F2F2F2;
@@ -17,6 +18,7 @@ $green: #72CEAA; // Barf
 $light-green: #ECF6F2; // Playtime
 $blue: #3497FF; // Good boy blue
 $purple: #59518b; // Pupple
+$light-purple: #908E9E;
 
 // Custom icon colors
 $dribble-pink: #EB4C89; // Dribble icon

--- a/scss/underdog/variables/_font.scss
+++ b/scss/underdog/variables/_font.scss
@@ -50,5 +50,7 @@ $font-weight-normal: 400;
 $font-weight-bold: 600;
 
 // Text colors
-$text-color: $whitish-black;
-$small-heading-color: $dark-gray;
+$text-color: $dark-gray;
+$headline-color: $dark-gray;
+$subheader-color: $light-gray;
+$small-heading-color: $light-purple;

--- a/scss/underdog/variables/_forms.scss
+++ b/scss/underdog/variables/_forms.scss
@@ -5,10 +5,9 @@ $input-text-focus-border-color: $whitish-black;
 $input-text-disabled-bg: $gray-xf3;
 $input-text-error-border-color: $red;
 $input-checkbox-border-color: $gray-xdc;
-$input-checkbox-checked-bg: $dark-gray;
-$nested-checkbox-color: $dark-gray;
-$block-label-color: $dark-gray;
-$block-label-font-weight: $font-weight-bold;
+$input-checkbox-checked-bg: $light-purple;
+$nested-checkbox-color: $light-purple;
+$block-label-color: $light-purple;
 $block-label-margin: $quarter-spacing-unit;
 $block-label-error-color: $red;
 

--- a/scss/underdog/variables/_links.scss
+++ b/scss/underdog/variables/_links.scss
@@ -1,10 +1,10 @@
 // Link coloring
 $link-color: $purple;
 $link-hover-color: $black;
-$link-disabled-color: $dark-gray;
+$link-disabled-color: $light-purple;
 $nav-link-hover-color: $black;
 $nav-link-color: $whitish-black;
 $nav-link-active-color: $black;
 $nav-link-active-font-weight: $font-weight-bold;
-$nav-link-disabled-color: $dark-gray;
+$nav-link-disabled-color: $light-purple;
 $menu-link-color: $purple;

--- a/scss/underdog/variables/_list-heading.scss
+++ b/scss/underdog/variables/_list-heading.scss
@@ -1,4 +1,4 @@
-$list-heading-color: $dark-gray !default;
+$list-heading-color: $light-purple !default;
 $list-heading-font-weight: $font-weight-bold;
 $list-heading-padding: $half-spacing-unit $base-spacing-unit !default;
 $list-heading-border: 1px solid $gray-xdc;


### PR DESCRIPTION
Updates subheaders (all headings besides `<h1 />`) to have a lighter gray color, `#777`.

I also updated the name of the `$light-gray` variable (in use in block-labels and small headings) to be `$light-purple`.

**Typography**

*Before*

<img width="1680" alt="screen shot 2016-06-21 at 6 07 48 pm" src="https://cloud.githubusercontent.com/assets/6979137/16248113/29db1cc0-37db-11e6-8bea-adfd61ba1e6c.png">

*After*

<img width="1679" alt="screen shot 2016-06-21 at 6 05 36 pm" src="https://cloud.githubusercontent.com/assets/6979137/16248074/f8de9bc4-37da-11e6-8b21-6e040c246296.png">

**Forms**

*Before*

<img width="1680" alt="screen shot 2016-06-21 at 6 08 12 pm" src="https://cloud.githubusercontent.com/assets/6979137/16248136/49e01610-37db-11e6-9fe8-d4e562dc72a2.png">

*After*

<img width="1680" alt="screen shot 2016-06-21 at 6 05 46 pm" src="https://cloud.githubusercontent.com/assets/6979137/16248076/fbaf5050-37da-11e6-890f-03ff47c89d24.png">

**Slabs**

*Before*

<img width="1679" alt="screen shot 2016-06-21 at 6 08 00 pm" src="https://cloud.githubusercontent.com/assets/6979137/16248137/4e4fb8c2-37db-11e6-865e-e5dc8478efab.png">

*After*

<img width="1679" alt="screen shot 2016-06-21 at 6 05 57 pm" src="https://cloud.githubusercontent.com/assets/6979137/16248080/fe79399a-37da-11e6-8f66-a443cdf9810d.png">

/cc @underdogio/engineering 