### PR TITLE
Add a tooltip component

### DIFF
--- a/docs/tooltip.md
+++ b/docs/tooltip.md
@@ -1,0 +1,16 @@
+---
+title: Tooltip
+---
+
+Add a tooltip to an element by adding the class `tooltip`. You can set the content of
+the tooltip by setting the `aria-label` attribute.
+
+<div class="tooltip text--center border--top border--right border--bottom border--left" aria-label="This is tooltip">
+  Hover over me!
+</div>
+
+```html
+<div class="tooltip" aria-label="This is tooltip">
+  Hover over me!
+</div>
+```

--- a/scss/underdog/_underdog.scss
+++ b/scss/underdog/_underdog.scss
@@ -29,6 +29,7 @@
 @import 'components/sidebar';
 @import 'components/slab';
 @import 'components/spinner';
+@import 'components/tooltip';
 @import 'components/well';
 
 // Trumps

--- a/scss/underdog/_variables.scss
+++ b/scss/underdog/_variables.scss
@@ -45,4 +45,5 @@
 @import 'variables/section-divider';
 @import 'variables/slab';
 @import 'variables/spinner';
+@import 'variables/tooltip';
 @import 'variables/well';

--- a/scss/underdog/components/_tooltip.scss
+++ b/scss/underdog/components/_tooltip.scss
@@ -1,0 +1,40 @@
+.tooltip {
+  position: relative;
+
+  &:before {
+    @include triangle($tooltip-bg, $tooltip-triangle-size);
+    content: '';
+    display: inline-block;
+    left: 50%;
+    opacity: 0;
+    position: absolute;
+    top: 100%;
+    transform: translateX(-50%);
+  }
+
+  &:after {
+    background: $tooltip-bg;
+    border-radius: $border-radius;
+    color: $tooltip-color;
+    content: attr(aria-label);
+    display: inline-block;
+    font-size: $tooltip-font-size;
+    left: 50%;
+    // Make room for the triangle
+    margin-top: $tooltip-triangle-size / 2;
+    opacity: 0;
+    padding: $tooltip-padding;
+    position: absolute;
+    pointer-events: none;
+    top: 100%;
+    transform: translateX(-50%);
+  }
+
+  &:hover {
+    &:before,
+    &:after {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+}

--- a/scss/underdog/variables/_tooltip.scss
+++ b/scss/underdog/variables/_tooltip.scss
@@ -1,0 +1,5 @@
+$tooltip-bg: $whitish-black;
+$tooltip-color: $white;
+$tooltip-font-size: 12px;
+$tooltip-padding: $quarter-spacing-unit;
+$tooltip-triangle-size: 10px;


### PR DESCRIPTION
Adds a tooltip component that can be used by applying the class `tooltip` to any element, and setting the content of the tooltip with an `aria-label` attribute.

```html
<div class="tooltip" aria-label="Hi I am tooltip">
   Hover over me
</div>
```

![untitled gif](https://cloud.githubusercontent.com/assets/6979137/16274955/e553ec3a-3875-11e6-9ad2-ae254c643a6e.gif)

/cc @underdogio/engineering 