### PR TITLE
Add nav-list component

### DIFF
--- a/docs/nav-list.md
+++ b/docs/nav-list.md
@@ -1,0 +1,119 @@
+---
+title: Nav List
+---
+
+A nav list is a list of links to other pages within a site or application.
+
+<ul class="nav-list">
+  <li class="nav-list__item">
+    <a class="nav-list__link" href="#">
+      Item One
+    </a>
+  </li>
+  <li class="nav-list__item">
+    <a class="nav-list__link" href="#">
+      Item Two
+    </a>
+  </li>
+  <li class="nav-list__item">
+    <a class="nav-list__link" href="#">
+      Item Three
+    </a>
+  </li>
+  <li class="nav-list__item">
+    <a class="nav-list__btn btn btn--secondary" href="#">
+      Login
+    </a>
+  </li>
+</ul>
+
+```html
+<ul class="nav-list">
+  <li class="nav-list__item">
+    <a class="nav-list__link" href="#">
+      Item One
+    </a>
+  </li>
+  <li class="nav-list__item">
+    <a class="nav-list__link" href="#">
+      Item Two
+    </a>
+  </li>
+  <li class="nav-list__item">
+    <a class="nav-list__link" href="#">
+      Item Three
+    </a>
+  </li>
+  <li class="nav-list__item">
+    <a class="nav-list__btn btn btn--secondary" href="#">
+      Login
+    </a>
+  </li>
+</ul>
+```
+
+Example within a header:
+
+<div class="header">
+  <a class="header__logo" href="#">
+    <img class="hidden--small" src="/dist/img/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
+    <img class="hidden--medium-and-up" src="/dist/img/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
+  </a>
+  <nav class="header__nav">
+    <ul class="nav-list">
+      <li class="nav-list__item">
+        <a class="nav-list__link" href="#">
+          Item One
+        </a>
+      </li>
+      <li class="nav-list__item">
+        <a class="nav-list__link" href="#">
+          Item Two
+        </a>
+      </li>
+      <li class="nav-list__item">
+        <a class="nav-list__link" href="#">
+          Item Three
+        </a>
+      </li>
+      <li class="nav-list__item">
+        <a class="nav-list__btn btn btn--secondary" href="#">
+          Login
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>
+
+```html
+<div class="header">
+  <a class="header__logo" href="#">
+    <img class="hidden--small" src="/dist/img/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
+    <img class="hidden--medium-and-up" src="/dist/img/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
+  </a>
+  <nav class="header__nav">
+    <ul class="nav-list">
+      <li class="nav-list__item">
+        <a class="nav-list__link" href="#">
+          Item One
+        </a>
+      </li>
+      <li class="nav-list__item">
+        <a class="nav-list__link" href="#">
+          Item Two
+        </a>
+      </li>
+      <li class="nav-list__item">
+        <a class="nav-list__link" href="#">
+          Item Three
+        </a>
+      </li>
+      <li class="nav-list__item">
+        <a class="nav-list__btn btn btn--secondary" href="#">
+          Login
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>
+```

--- a/scss/underdog/_underdog.scss
+++ b/scss/underdog/_underdog.scss
@@ -25,6 +25,7 @@
 @import 'components/menu-drawer';
 @import 'components/menu-list';
 @import 'components/modal';
+@import 'components/nav-list';
 @import 'components/section-divider';
 @import 'components/sidebar';
 @import 'components/slab';

--- a/scss/underdog/_variables.scss
+++ b/scss/underdog/_variables.scss
@@ -41,6 +41,7 @@
 @import 'variables/menu-drawer';
 @import 'variables/menu-list';
 @import 'variables/modal';
+@import 'variables/nav-list';
 @import 'variables/opacity';
 @import 'variables/section-divider';
 @import 'variables/slab';

--- a/scss/underdog/components/_nav-list.scss
+++ b/scss/underdog/components/_nav-list.scss
@@ -1,0 +1,45 @@
+.nav-list {
+  display: block;
+}
+
+.nav-list__item {
+  display: inline-block;
+  margin-left: $nav-list-item-spacing;
+  vertical-align: middle;
+
+  &:first-child {
+    margin-left: 0;
+  }
+}
+
+.nav-list__link,
+.nav-list__btn {
+  font-size: $nav-list-font-size;
+}
+
+.nav-list__link {
+  @include all-caps;
+  color: inherit;
+  position: relative;
+  text-decoration: none;
+
+  &:after {
+    @include transition(opacity);
+    background: $nav-list-item-border-color;
+    content: '';
+    display: block;
+    height: $nav-list-item-border-width;
+    left: 0;
+    margin-top: $nav-list-item-border-spacing;
+    opacity: 0;
+    position: absolute;
+    top: 100%;
+    width: 100%;
+  }
+
+  &:hover {
+    &:after {
+      opacity: 1;
+    }
+  }
+}

--- a/scss/underdog/variables/_nav-list.scss
+++ b/scss/underdog/variables/_nav-list.scss
@@ -1,0 +1,5 @@
+$nav-list-font-size: 12px;
+$nav-list-item-border-color: $gray-xdc;
+$nav-list-item-border-spacing: $quarter-spacing-unit;
+$nav-list-item-border-width: 2px;
+$nav-list-item-spacing: $base-spacing-width;


### PR DESCRIPTION
Adds a `nav-list` component for listing navigation links in a site/app header.

Nav list on its own:

<img width="390" alt="screen shot 2016-06-22 at 1 10 13 pm" src="https://cloud.githubusercontent.com/assets/6979137/16276014/ae2c3d8e-387a-11e6-8f5d-2edc2a18251d.png">

Nav list within a header:

<img width="1136" alt="screen shot 2016-06-22 at 1 08 33 pm" src="https://cloud.githubusercontent.com/assets/6979137/16275984/952cef18-387a-11e6-96e7-38ba561767aa.png">

/cc @underdogio/engineering 