### PR TITLE
Fix alignment of anchor and button elements in button groups

### DIFF
--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -180,9 +180,9 @@ Button groups can be grouped within a `.btn-group`. Button groups can contain an
 type of button.
 
 <div class="btn-group">
-  <button class="btn btn--primary">
-    A button
-  </button>
+  <a class="btn btn--primary" href="mailto:bark@underdog.io">
+    Email
+  </a>
   <button class="btn btn--primary btn--small">
     <span class="icon icon-arrow icon--small">
     </span>
@@ -201,9 +201,9 @@ type of button.
 
 ```html
 <div class="btn-group">
-  <button class="btn btn--primary">
-    A button
-  </button>
+  <a class="btn btn--primary" href="mailto:bark@underdog.io">
+    Email
+  </a>
   <button class="btn btn--primary btn--small">
     <span class="icon icon-arrow icon--small">
     </span>

--- a/scss/underdog/objects/_buttons.scss
+++ b/scss/underdog/objects/_buttons.scss
@@ -118,6 +118,8 @@
     border-radius: 0;
     border-right: $btn-group-border;
     float: left;
+    // Normalize line-height between <button /> and <a /> elements
+    line-height: inherit;
 
     &:nth-child(n+2) {
       // Remove left border after first button to avoid conflict with right border


### PR DESCRIPTION
Fixes an issue where buttons of different element types weren't aligning vertically. This has something to do with `<button />` elements having a default line-height set to `normal`, while `<a />` elements inherit their line-height from their parent element. This PR remedies that by forcing all elements within a button group to inherit their line-height.

In these screenshots the left button is an `<a />` element, and the right button is a `<button />` element.

*Before*

<img width="318" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16315980/61b18f30-3952-11e6-9d0f-22b12e1601a4.png">

*After*

<img width="335" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/16316010/7d102a16-3952-11e6-8c64-4f03764bba61.png">

/cc @underdogio/engineering 