### PR TITLE
Add modifiers for positioning tooltips

### DIFF
--- a/docs/tooltip.md
+++ b/docs/tooltip.md
@@ -5,12 +5,28 @@ title: Tooltip
 Add a tooltip to an element by adding the class `tooltip`. You can set the content of
 the tooltip by setting the `aria-label` attribute.
 
-<div class="tooltip text--center border--top border--right border--bottom border--left" aria-label="This is tooltip">
-  Hover over me!
+<div class="tooltip text--center border--top border--right border--bottom border--left" aria-label="This is tooltip" style="margin-bottom: 4em;">
+  Center tooltip
+</div>
+
+<div class="tooltip tooltip--right text--center border--top border--right border--bottom border--left" aria-label="This is tooltip" style="margin-bottom: 4em;">
+  Right tooltip
+</div>
+
+<div class="tooltip tooltip--left text--center border--top border--right border--bottom border--left" aria-label="This is tooltip" style="margin-bottom: 4em;">
+  Left tooltip
 </div>
 
 ```html
 <div class="tooltip" aria-label="This is tooltip">
+  Hover over me!
+</div>
+
+<div class="tooltip tooltip--right" aria-label="This is tooltip">
+  Hover over me!
+</div>
+
+<div class="tooltip tooltip--left" aria-label="This is tooltip">
   Hover over me!
 </div>
 ```

--- a/scss/underdog/components/_tooltip.scss
+++ b/scss/underdog/components/_tooltip.scss
@@ -38,3 +38,21 @@
     }
   }
 }
+
+.tooltip--right {
+  &:before,
+  &:after {
+    left: auto;
+    right: 0;
+    transform: none;
+  }
+}
+
+.tooltip--left {
+  &:before,
+  &:after {
+    left: 0;
+    right: auto;
+    transform: none;
+  }
+}


### PR DESCRIPTION
Adds a few modifier classes for tooltips that allow them to be positioned the left or right of their parent element.

![untitled gif](https://cloud.githubusercontent.com/assets/6979137/16316095/d23c07e4-3952-11e6-802a-7f522cccb90b.gif)


/cc @underdogio/engineering 