### PR TITLE
Reset tooltip styling when placed in a button

### DIFF
--- a/docs/tooltip.md
+++ b/docs/tooltip.md
@@ -5,28 +5,29 @@ title: Tooltip
 Add a tooltip to an element by adding the class `tooltip`. You can set the content of
 the tooltip by setting the `aria-label` attribute.
 
-<div class="tooltip text--center border--top border--right border--bottom border--left" aria-label="This is tooltip" style="margin-bottom: 4em;">
+<button class="btn btn--primary tooltip" aria-label="This is tooltip">
   Center tooltip
-</div>
+</button>
 
-<div class="tooltip tooltip--right text--center border--top border--right border--bottom border--left" aria-label="This is tooltip" style="margin-bottom: 4em;">
-  Right tooltip
-</div>
-
-<div class="tooltip tooltip--left text--center border--top border--right border--bottom border--left" aria-label="This is tooltip" style="margin-bottom: 4em;">
+<button class="btn btn--primary tooltip tooltip--left" aria-label="This is tooltip">
   Left tooltip
-</div>
+</button>
+
+<button class="btn btn--primary tooltip tooltip--right" aria-label="This is tooltip">
+  Right tooltip
+</button>
 
 ```html
-<div class="tooltip" aria-label="This is tooltip">
-  Hover over me!
-</div>
 
-<div class="tooltip tooltip--right" aria-label="This is tooltip">
-  Hover over me!
-</div>
+<button class="btn btn--primary tooltip" aria-label="This is tooltip">
+  Center tooltip
+</button>
 
-<div class="tooltip tooltip--left" aria-label="This is tooltip">
-  Hover over me!
-</div>
+<button class="btn btn--primary tooltip tooltip--left" aria-label="This is tooltip">
+  Left tooltip
+</button>
+
+<button class="btn btn--primary tooltip tooltip--right" aria-label="This is tooltip">
+  Right tooltip
+</button>
 ```

--- a/scss/underdog/components/_tooltip.scss
+++ b/scss/underdog/components/_tooltip.scss
@@ -1,6 +1,14 @@
 .tooltip {
   position: relative;
 
+  &:before,
+  &:after {
+    // Reset font styling when placed within a button
+    font-size: $tooltip-font-size;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+
   &:before {
     @include triangle($tooltip-bg, $tooltip-triangle-size);
     content: '';
@@ -18,7 +26,6 @@
     color: $tooltip-color;
     content: attr(aria-label);
     display: inline-block;
-    font-size: $tooltip-font-size;
     left: 50%;
     // Make room for the triangle
     margin-top: $tooltip-triangle-size / 2;


### PR DESCRIPTION
Fixes an issue where tooltips would inherit button styles when used with a button.

*Before*

<img width="295" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16316301/07dc971e-3954-11e6-9fc5-da35218a737a.png">

*After*

![untitled gif 1](https://cloud.githubusercontent.com/assets/6979137/16316463/b8363b88-3954-11e6-9b52-4f448d666265.gif)

/cc @underdogio/engineering 