### PR TITLE
Remove background color from heros

### DIFF
--- a/docs/hero.md
+++ b/docs/hero.md
@@ -10,24 +10,34 @@ be the first element in a page, and there should never be more than one hero on 
 ### Default hero
 
 <div class="hero">
-  <div>
-    <h1 class="push18--bottom">Apply to top startup jobs in 60 seconds</h1>
-    <p class="gamma push25--bottom">We connect candidates with awesome New York, San Francisco, and remote companies</p>
-    <div>
-      <a class="btn btn--secondary push18--right" href="#hero">Candidates</a>
-      <a class="btn btn--secondary push18--left" href="#hero">Startups</a>
+  <div class="hero__content">
+    <img class="hero__image" alt=" " src="/dist/img/assembly_line.svg" />
+    <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
+    <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
+    <div class="row">
+      <div class="col-5-large-and-up offset-1-large-and-up push18--bottom">
+        <a class="btn btn--primary btn--large btn--block" href="#hero">Candidates</a>
+      </div>
+      <div class="col-5-large-and-up">
+        <a class="btn btn--primary btn--large btn--block" href="#hero">Companies</a>
+      </div>
     </div>
   </div>
 </div>
 
 ```html
 <div class="hero">
-  <div>
-    <h1 class="push18--bottom">Apply to top startup jobs in 60 seconds</h1>
-    <p class="gamma push25--bottom">We connect candidates with awesome New York, San Francisco, and remote companies</p>
-    <div>
-      <a class="btn btn--secondary push18--right" href="#hero">Candidates</a>
-      <a class="btn btn--secondary push18--left" href="#hero">Startups</a>
+  <div class="hero__content">
+    <img class="hero__image" alt=" " src="/dist/img/assembly_line.svg" />
+    <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
+    <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
+    <div class="row">
+      <div class="col-5-large-and-up offset-1-large-and-up push18--bottom">
+        <a class="btn btn--primary btn--large btn--block" href="#hero">Candidates</a>
+      </div>
+      <div class="col-5-large-and-up">
+        <a class="btn btn--primary btn--large btn--block" href="#hero">Companies</a>
+      </div>
     </div>
   </div>
 </div>
@@ -38,24 +48,34 @@ be the first element in a page, and there should never be more than one hero on 
 Use the `.hero--large` modifier to get a larger hero that will scale to take up a majority of the viewport height.
 
 <div class="hero hero--large">
-  <div>
-    <h1 class="push18--bottom">Apply to top startup jobs in 60 seconds</h1>
-    <p class="gamma push25--bottom">We connect candidates with awesome New York, San Francisco, and remote companies</p>
-    <div>
-      <a class="btn btn--secondary push18--right" href="#hero">Candidates</a>
-      <a class="btn btn--secondary push18--left" href="#hero">Startups</a>
+  <div class="hero__content">
+    <img class="hero__image" alt=" " src="/dist/img/assembly_line.svg" />
+    <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
+    <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
+    <div class="row">
+      <div class="col-5-large-and-up offset-1-large-and-up push18--bottom">
+        <a class="btn btn--primary btn--large btn--block" href="#hero">Candidates</a>
+      </div>
+      <div class="col-5-large-and-up">
+        <a class="btn btn--primary btn--large btn--block" href="#hero">Companies</a>
+      </div>
     </div>
   </div>
 </div>
 
 ```html
-<div class="hero--large">
-  <div>
-    <h1 class="push18--bottom">Apply to top startup jobs in 60 seconds</h1>
-    <p class="gamma push25--bottom">We connect candidates with awesome New York, San Francisco, and remote companies</p>
-    <div>
-      <a class="btn btn--secondary push18--right" href="#hero">Candidates</a>
-      <a class="btn btn--secondary push18--left" href="#hero">Startups</a>
+<div class="hero hero--large">
+  <div class="hero__content">
+    <img class="hero__image" alt=" " src="/dist/img/assembly_line.svg" />
+    <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
+    <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
+    <div class="row">
+      <div class="col-5-large-and-up offset-1-large-and-up push18--bottom">
+        <a class="btn btn--primary btn--large btn--block" href="#hero">Candidates</a>
+      </div>
+      <div class="col-5-large-and-up">
+        <a class="btn btn--primary btn--large btn--block" href="#hero">Companies</a>
+      </div>
     </div>
   </div>
 </div>

--- a/images/assembly_line.svg
+++ b/images/assembly_line.svg
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="536px" height="140.1px" viewBox="0 0 536 140.1" enable-background="new 0 0 536 140.1" xml:space="preserve">
+<g>
+	<g>
+		<path fill="#59518B" d="M510.4,6.7c-5.8-2-16.8-3.3-29.3-3.3c-12.6,0-23.5,1.3-29.3,3.3c5.8,2,16.8,3.3,29.3,3.3
+			C493.6,10,504.6,8.6,510.4,6.7z"/>
+	</g>
+	<ellipse fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="481.1" cy="8.3" rx="32.7" ry="6.3"/>
+	<rect x="492.9" y="3.2" fill="#FFFFFF" width="8.6" height="134.8"/>
+	<g>
+		<g>
+			<line fill="none" stroke="#EC724F" stroke-width="2" stroke-miterlimit="10" x1="443" y1="119.3" x2="444" y2="119.3"/>
+			
+				<line fill="none" stroke="#EC724F" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="1.8309,0.9154" x1="445" y1="119.3" x2="458.2" y2="119.3"/>
+			<line fill="none" stroke="#EC724F" stroke-width="2" stroke-miterlimit="10" x1="458.7" y1="119.3" x2="459.7" y2="119.3"/>
+		</g>
+	</g>
+	<path fill="none" stroke="#EC724F" stroke-width="2" stroke-miterlimit="10" d="M398,59.3c3,5.7,2,18.8,11.4,21.2
+		s12.3-4.6,12.3-4.6"/>
+	<polyline fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" points="502,7.2 503.5,9.8 501.5,13.1 503.5,16.4 
+		501.5,19.7 503.5,22.9 501.5,26.2 503.5,29.5 501.5,32.8 503.5,36.1 501.5,39.4 503.5,42.7 501.5,46 503.5,49.2 501.5,52.5 
+		503.5,55.8 501.5,59.1 503.5,62.4 501.5,65.7 503.5,69 501.5,72.3 503.5,75.5 501.5,78.8 503.5,82.1 501.5,85.4 503.5,88.7 
+		501.5,92 503.5,95.3 501.5,98.6 503.5,101.8 501.5,105.1 503.5,108.4 501.5,111.7 503.5,115 501.5,118.3 503.5,121.6 501.5,124.9 
+		503.5,128.2 501.5,131.5 503.5,134.8 501.5,138.1 	"/>
+	<path fill="#72CEAA" d="M321.4,39.8c0,0,0.9-1.8,4.2-1.8c3,0,5.4,6,9.9-0.3c0,0,1,8.5-7.1,8.5C320.3,46.2,321.4,39.8,321.4,39.8z"
+		/>
+	<polygon fill="#72CEAA" points="501.5,138.1 497.2,138.1 497.2,7.6 501.5,8.1 	"/>
+	<path fill="#72CEAA" d="M306.5,115.6c-2.6,0.2-4.3-2.6-3.7-4.8c0.4-1.3,1.6-2.3,2-3.6c0.5-2-1.4-2.8-2.9-3.3
+		c-0.8-0.3-1.7-0.5-2.1-1.2c-0.1-0.2-0.2-0.5-0.3-0.7c-0.3-0.9-0.4-2,0.1-2.9c0.4-0.7,1.2-1.2,1.9-1.5c0.8-0.3,1.6-0.5,2.4-0.8
+		c0.7-0.3,1.6-0.9,1.8-1.6c0.4-1.6-1.8-3.7-2.1-5.2c-0.5-2.3,1.2-4.2,3.6-3.8c0.7,0.1,1.3,0.6,1.8,1.1c0.7,0.7,1.5,1.8,2.7,1.7
+		c0.9,0,1.2-1,1.4-1.7c0.6-1.9,0.7-5.3,3-6c6.1-1.9,3.9,9.7,10.1,7.5c2-0.7,3.4-5.1,6.1-4c2.1,0.9,1.1,4.6,3.9,4.7
+		c1.4,0.1,2.7-1.5,3.4-2.4c1-1.3,2-2.6,3.2-3.7c0.4-0.3,0.7-0.6,1.2-0.8c0.5-0.1,1-0.1,1.3,0.3c0.2,0.2,0.3,0.6,0.3,0.9
+		c0.3,1.9-0.3,3.9,0.4,5.7c0.6,1.6,2.1,2.8,3.8,2.9c2.2,0.2,4.2,0,5.4,2.3c0.6,1.2,0.2,2.3-0.5,3.3c-1.4,2-4.6,3.7-4.8,6.4
+		c0,0.6,0.1,1.1,0.4,1.6c1.3,2.1,5.9,3,4.7,6.2c-0.9,2.3-4.6,1.9-6,3.9"/>
+	<rect x="324.2" y="97.6" fill="#FFFFFF" width="18.4" height="18.4"/>
+	<rect x="318.4" y="97.6" fill="#FFFFFF" width="4.9" height="18.4"/>
+	<rect x="270.7" y="97.6" fill="#72CEAA" width="18.4" height="18.4"/>
+	<rect x="264.9" y="97.6" fill="#72CEAA" width="4.9" height="18.4"/>
+	<g>
+		<path fill="none" stroke="#EC724F" stroke-width="4" stroke-miterlimit="10" d="M358.9,116.1c1.1,1.1,1.8,2.7,1.8,4.4
+			c0,1.6-0.6,3.1-1.6,4.2"/>
+		<path fill="none" stroke="#EC724F" stroke-width="4" stroke-miterlimit="10" d="M351.8,116c1.2,1.1,2,2.8,2,4.6
+			c0,1.6-0.6,3.1-1.6,4.2"/>
+		<path fill="none" stroke="#EC724F" stroke-width="4" stroke-miterlimit="10" d="M344.9,116.1c1.1,1.1,1.8,2.7,1.8,4.4
+			s-0.7,3.3-1.8,4.4"/>
+	</g>
+	<polygon fill="#EC724F" points="120.1,68 109.4,68 109.4,93.7 104.5,97.2 104.5,57.8 120.1,57.8 	"/>
+	<g>
+		<polygon fill="#EC724F" points="168,101.5 144.9,101.5 147.8,113.9 168,113.9 		"/>
+		<rect x="174.3" y="104.6" fill="#EC724F" width="59" height="9.3"/>
+	</g>
+	<g>
+		<rect x="147.8" y="125.7" fill="#EC724F" width="20.2" height="12.4"/>
+		<rect x="174.3" y="125.7" fill="#EC724F" width="59" height="12.4"/>
+	</g>
+	<polygon fill="#59518B" points="149.7,75.6 206.3,75.6 236.9,104.6 180.2,104.6 	"/>
+	<polygon fill="#EC724F" points="155,88.7 124.1,88.7 139.7,74.4 	"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="4" stroke-miterlimit="10" x1="142" y1="76.7" x2="128.3" y2="76.7"/>
+	<path fill="#EC724F" d="M130,100.8c0.8-0.2,1.6-0.6,2.5-0.8c0.4-0.1,0.8,0.1,0.9,0.5c0,0.2,0,0.4-0.1,0.5H168l-13-12.4h-30.9
+		L111,101.1h18.5C129.6,101,129.8,100.9,130,100.8z"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="4" stroke-miterlimit="10" x1="155" y1="88.9" x2="115.1" y2="88.9"/>
+	<rect x="108.3" y="113.5" fill="#EC724F" width="13" height="12.4"/>
+	<polygon fill="#EC724F" points="121.3,113.5 108.3,113.5 108.3,101.1 124.3,101.1 	"/>
+	<rect x="108.3" y="125.7" fill="#EC724F" width="13" height="12.4"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="4" stroke-miterlimit="10" x1="121.3" y1="113.5" x2="102" y2="113.5"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="4" stroke-miterlimit="10" x1="121.3" y1="125.9" x2="102" y2="125.9"/>
+	<rect x="174.3" y="113.5" fill="#EC724F" width="59" height="12.4"/>
+	<polyline fill="#EC724F" points="147.8,113.5 168,113.5 168,125.9 147.8,125.9 	"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="4" stroke-miterlimit="10" x1="147.8" y1="125.8" x2="233.4" y2="125.8"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="4" stroke-miterlimit="10" x1="147.8" y1="113.5" x2="233.4" y2="113.5"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="4" stroke-miterlimit="10" x1="126.5" y1="101.2" x2="102.2" y2="101.2"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="4" stroke-miterlimit="10" x1="168" y1="101.2" x2="142.8" y2="101.2"/>
+	<g>
+		<path fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" d="M147.8,137.9v-26.5c0-7.3-5.9-13.2-13.2-13.2
+			c-7.3,0-13.2,5.9-13.2,13.2v26.5H147.8z"/>
+		<g>
+			<path fill="#59518B" d="M137.2,98.5c-6,1.2-10.6,6.6-10.6,13v26.5h21.2v-26.5C147.8,105,143.2,99.7,137.2,98.5z"/>
+		</g>
+	</g>
+	<polyline fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" points="135.2,70.2 168,101.2 168,138.1 	"/>
+	<polyline fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" points="233.4,101.2 200.6,70.2 135.2,70.2 
+		102.2,100.9 102,138.1 233.2,138.1 233.4,104.6 	"/>
+	<polyline fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" points="102.2,100.9 98.3,104.6 102.2,104.6 	"/>
+	<polyline fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" points="230.4,98.5 236.9,104.6 171.6,104.6 
+		165.1,98.5 	"/>
+	<path fill="#59518B" d="M141.8,91c0.6-0.3,1-0.8,1-1.5c0-0.9-0.7-1.6-1.6-1.6c-0.9,0-1.6,0.7-1.6,1.6c0,0,0,0.1,0,0.1h-8.7
+		c0,0,0-0.1,0-0.1c0-0.9-0.7-1.6-1.6-1.6c-0.9,0-1.6,0.7-1.6,1.6c0,0.7,0.4,1.2,1,1.5c-0.6,0.3-1,0.8-1,1.5c0,0.9,0.7,1.6,1.6,1.6
+		c0.9,0,1.6-0.7,1.6-1.6c0,0,0-0.1,0-0.1h8.7c0,0,0,0.1,0,0.1c0,0.9,0.7,1.6,1.6,1.6c0.9,0,1.6-0.7,1.6-1.6
+		C142.8,91.8,142.4,91.2,141.8,91z"/>
+	<path fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" d="M233.4,116.1h102.2c2.5,0,4.5,2,4.5,4.5
+		c0,2.5-2,4.5-4.5,4.5h-96.8"/>
+	<path fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" d="M335.5,116.1h27c2.5,0,4.5,2,4.5,4.5
+		c0,2.5-2,4.5-4.5,4.5h-27"/>
+	<circle fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="313.9" cy="120.6" r="4.5"/>
+	<circle fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="292.3" cy="120.6" r="4.5"/>
+	<circle fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="270.7" cy="120.6" r="4.5"/>
+	<circle fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="249.1" cy="120.6" r="4.5"/>
+	<path fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" d="M335.5,125.1c-2.5,0-4.5-2-4.5-4.5
+		c0-2.5,2-4.5,4.5-4.5"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="328.3" y1="125.1" x2="328.3" y2="138.1"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="355.3" y1="129.6" x2="355.3" y2="138.1"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="290.5" y1="125.1" x2="290.5" y2="138.1"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="317.5" y1="129.6" x2="317.5" y2="138.1"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="252.7" y1="125.1" x2="252.7" y2="138.1"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="279.7" y1="129.6" x2="279.7" y2="138.1"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="0" y1="138.1" x2="536" y2="138.1"/>
+	<g>
+		<polygon fill="#EC724F" points="47.9,61.1 44.9,61.1 44,56.7 47,56.7 		"/>
+		<polygon fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" points="59.9,76.7 44,76.7 40,56.4 55.9,56.4 		
+			"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="45.4" y1="63.7" x2="57" y2="63.7"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="46.2" y1="67.8" x2="57.8" y2="67.8"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="47" y1="71.9" x2="58.6" y2="71.9"/>
+	</g>
+	<g>
+		<polygon fill="#72CEAA" points="55.4,90.5 52.4,90.5 50.6,86.9 53.6,86.9 		"/>
+		<polygon fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" points="70.4,103.3 54.5,103.3 50.5,95 46.6,86.7 
+			62.5,86.7 		"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="53.4" y1="92.7" x2="65" y2="92.7"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="55" y1="96" x2="66.6" y2="96"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="56.6" y1="99.4" x2="68.2" y2="99.4"/>
+	</g>
+	<g>
+		<rect x="43.4" y="26.5" fill="#72CEAA" width="3" height="4.3"/>
+		<rect x="39.5" y="26.3" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="15.9" height="20.3"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="43.4" y1="33.6" x2="55" y2="33.6"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="43.4" y1="37.7" x2="55" y2="37.7"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="43.4" y1="41.7" x2="55" y2="41.7"/>
+	</g>
+	<line fill="none" stroke="#FFFFFF" stroke-width="4" stroke-miterlimit="10" x1="83.7" y1="118.6" x2="106.1" y2="118.6"/>
+	<polygon fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" points="76.6,115.9 60.7,115.9 59.9,114.7 
+		59.1,113.6 75.1,113.6 	"/>
+	<polygon fill="none" stroke="#59518B" stroke-width="3" stroke-miterlimit="10" points="104.3,116.5 88.4,116.5 88.1,115.9 
+		87.8,115.3 103.7,115.3 	"/>
+	<polygon fill="none" stroke="#59518B" stroke-width="3" stroke-miterlimit="10" points="133.2,116.5 117.3,116.5 117,115.9 
+		116.7,115.3 132.6,115.3 	"/>
+	<rect x="260.4" y="97.6" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="10.3" height="18.4"/>
+	<rect x="270.7" y="97.6" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="18.4" height="18.4"/>
+	<rect x="313.9" y="97.6" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="10.3" height="18.4"/>
+	<rect x="324.2" y="97.6" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="18.4" height="18.4"/>
+	<g>
+		<path fill="#59518B" d="M77.1,6.7c-5.8-2-16.8-3.3-29.3-3.3c-12.6,0-23.5,1.3-29.3,3.3c5.8,2,16.8,3.3,29.3,3.3
+			C60.3,10,71.2,8.6,77.1,6.7z"/>
+	</g>
+	<ellipse fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="47.7" cy="8.3" rx="32.7" ry="6.3"/>
+	<g>
+		<rect x="39.5" y="5.4" fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="15.9" height="10.4"/>
+		<line fill="none" stroke="#59518B" stroke-width="2" stroke-miterlimit="10" x1="43.4" y1="11" x2="55" y2="11"/>
+	</g>
+	<polygon fill="#72CEAA" points="360.8,51.7 361.4,57.2 383.6,55.4 383.6,49.9 	"/>
+	<rect x="390.6" y="61" fill="#72CEAA" width="6" height="50.1"/>
+	<path fill="none" stroke="#EC724F" stroke-width="2" stroke-miterlimit="10" d="M390.3,90.1c0,0-10.3,7.6-12.6,15.7
+		c-3.3,11.4,3.1,17.2,7,21"/>
+	<path fill="none" stroke="#EC724F" stroke-width="2" stroke-miterlimit="10" d="M400.5,55.4c0,0,7.2,3.1,6.7,12.8
+		c-0.6,11.6-8.4,15.6-10.3,20.1"/>
+	<path fill="none" stroke="#EC724F" stroke-width="2" stroke-miterlimit="10" d="M352.2,46.2c-3.9-5.9,2.6-15.2,13.9-7.9
+		c14.5,9.3,22.9-6.9,28.1,4.6"/>
+	<polyline fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" points="384.7,138.1 384.7,111.1 402.5,111.1 
+		402.5,138.1 	"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="396.6" y1="59.3" x2="396.6" y2="111.1"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="390.6" y1="111.1" x2="390.6" y2="59.3"/>
+	<circle fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="393.6" cy="51.7" r="8.8"/>
+	<circle fill="#59518B" cx="393.6" cy="51.7" r="3.3"/>
+	<circle fill="#59518B" cx="351.6" cy="55" r="3.3"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="386.3" y1="54.8" x2="359.6" y2="56.9"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="358.9" y1="51.8" x2="385.6" y2="49.7"/>
+	<circle fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="351.6" cy="55" r="8.8"/>
+	<polygon fill="#72CEAA" points="423,66.3 420,71 400.9,59.5 403.4,54.5 	"/>
+	<circle fill="#59518B" cx="429.7" cy="75.1" r="3.3"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="398.7" y1="57.7" x2="421.7" y2="71.5"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="424.6" y1="67.3" x2="401.6" y2="53.5"/>
+	<circle fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="429.7" cy="75.1" r="8.8"/>
+	<rect x="390.1" y="111.1" fill="#59518B" width="12.3" height="27"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="342.9" y1="56.3" x2="328.6" y2="58.3"/>
+	<circle fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="328.6" cy="58.3" r="4.7"/>
+	<circle fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="328.6" cy="39.8" r="7.2"/>
+	<line fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="328.6" y1="62.9" x2="328.6" y2="78.7"/>
+	<line fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="322.3" y1="68.2" x2="334.9" y2="68.2"/>
+	<line fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="328.6" y1="53.6" x2="328.6" y2="47"/>
+	<circle fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" cx="417.2" cy="119.3" r="4.7"/>
+	<line fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="421.9" y1="119.3" x2="443.9" y2="119.3"/>
+	<line fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="438.9" y1="123.8" x2="438.9" y2="114.8"/>
+	<line fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="433.5" y1="125.6" x2="433.5" y2="113"/>
+	<line fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="428.1" y1="127.4" x2="428.1" y2="111.2"/>
+	<line fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="418.4" y1="115.5" x2="427.3" y2="81.8"/>
+	<path fill="#59518B" d="M443,122.3v-6c1.7,0,3,1.3,3,3C446,120.9,444.7,122.3,443,122.3z"/>
+	<line fill="#FFFFFF" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="324.1" y1="73.6" x2="333.1" y2="73.6"/>
+	<path fill="#59518B" d="M325.6,77.7h6c0,1.7-1.3,3-3,3S325.6,79.4,325.6,77.7z"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="501.9" y1="3.2" x2="501.9" y2="138.1"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="492.9" y1="138.1" x2="492.9" y2="3.2"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="492.9" y1="128.6" x2="461.2" y2="128.6"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="492.9" y1="96.2" x2="461.2" y2="96.2"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="492.9" y1="63.8" x2="461.2" y2="63.8"/>
+	<line fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" x1="492.9" y1="31.4" x2="461.2" y2="31.4"/>
+	<rect x="457.6" y="45.4" fill="#EC724F" width="18.4" height="18.4"/>
+	<rect x="476.9" y="45.4" fill="#EC724F" width="4.9" height="18.4"/>
+	<rect x="476" y="45.4" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="10.3" height="18.4"/>
+	<rect x="457.6" y="45.4" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="18.4" height="18.4"/>
+	<polygon fill="#FFFFFF" points="466.8,50.7 467.7,53.6 470.7,53.6 468.3,55.4 469.2,58.2 466.8,56.5 464.3,58.2 465.3,55.4 
+		462.8,53.6 465.9,53.6 	"/>
+	<rect x="457.6" y="114.4" fill="#EC724F" width="18.4" height="14.2"/>
+	<rect x="476.9" y="114.4" fill="#EC724F" width="4.9" height="14.2"/>
+	<rect x="476" y="110.2" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="10.3" height="18.4"/>
+	<rect x="457.6" y="110.2" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="18.4" height="18.4"/>
+	<polygon fill="#FFFFFF" points="466.8,115.5 467.7,118.4 470.7,118.4 468.3,120.2 469.2,123 466.8,121.3 464.3,123 465.3,120.2 
+		462.8,118.4 465.9,118.4 	"/>
+	<rect x="457.6" y="13" fill="#EC724F" width="18.4" height="18.4"/>
+	<rect x="476.9" y="13" fill="#FFFFFF" width="9.4" height="18.4"/>
+	<rect x="476.9" y="13" fill="#EC724F" width="4.9" height="18.4"/>
+	<rect x="476" y="13" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="10.3" height="18.4"/>
+	<rect x="457.6" y="13" fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" width="18.4" height="18.4"/>
+	<polygon fill="#FFFFFF" points="466.8,18.3 467.7,21.2 470.7,21.2 468.3,23 469.2,25.8 466.8,24.1 464.3,25.8 465.3,23 462.8,21.2 
+		465.9,21.2 	"/>
+	<path fill="none" stroke="#59518B" stroke-width="4" stroke-miterlimit="10" d="M492.5,2.4c4.5,0.3,8.5,0.8,11.8,1.5"/>
+</g>
+</svg>

--- a/scss/underdog/objects/_hero.scss
+++ b/scss/underdog/objects/_hero.scss
@@ -1,17 +1,10 @@
 // SEE: hero.md
 .hero {
   align-items: center;
-  background: $hero-bg;
-  color: $hero-color;
   display: flex;
   justify-content: center;
   padding: $hero-padding;
   text-align: center;
-
-  h1, h2, h3, h4, h5, h6 {
-    // Remove default dark text color from headings
-    color: inherit;
-  }
 
   a:not(.btn) {
     // Make links visible
@@ -25,7 +18,31 @@
   }
 }
 
+.hero__content {
+  max-width: $hero-max-width;
+}
+
+.hero__title {
+  @extend .push30--bottom;
+  font-size: $hero-title-font-size;
+  font-weight: $hero-title-font-weight;
+  line-height: normal;
+}
+
+.hero__image {
+  @extend .push45--bottom;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hero__subtitle {
+  @extend .beta;
+  @extend .push45--bottom;
+  color: $hero-subtitle-color;
+  line-height: normal;
+}
+
 .hero--large {
-  height: $hero-large-height;
   min-height: $hero-large-min-height;
 }

--- a/scss/underdog/variables/_font.scss
+++ b/scss/underdog/variables/_font.scss
@@ -2,6 +2,7 @@
 
 // Base sizes
 $p-font-size: 14px;
+$huge-font-size: 37.5px;
 $alpha-font-size: 30px;
 $beta-font-size: 20px;
 $gamma-font-size: 15px;
@@ -46,6 +47,7 @@ $hr-font-size: 14px;
 $th-small-font-size: 14px;
 
 // Font weights
+$font-weight-light: 300;
 $font-weight-normal: 400;
 $font-weight-bold: 600;
 

--- a/scss/underdog/variables/_hero.scss
+++ b/scss/underdog/variables/_hero.scss
@@ -1,6 +1,11 @@
 $hero-bg: $green;
 $hero-color: $white;
 $hero-padding: ($base-spacing-unit * 4) $base-spacing-width;
+$hero-max-width: 50rem;
 
-$hero-large-min-height: 320px;
-$hero-large-height: 80vh;
+$hero-large-min-height: 90vh;
+
+$hero-subtitle-color: $subheader-color;
+
+$hero-title-font-size: $huge-font-size;
+$hero-title-font-weight: $font-weight-light;

--- a/server/views/layouts/main.hbs
+++ b/server/views/layouts/main.hbs
@@ -26,7 +26,7 @@
     <link rel="mask-icon" href="/dist/safari-pinned-tab.svg" color="#524b7a" />
 
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.2.0/styles/github.min.css" />
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,400italic,600" />
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300,400,400italic,600" />
     <link rel="stylesheet" href="/dist/css/underdog.css" />
     <link rel="stylesheet" href="/dist/css/styleguide.css" />
 


### PR DESCRIPTION
Removes the solid background color from heros, and adds a few other visual changes.

*Before*

<img width="1122" alt="hero-before" src="https://cloud.githubusercontent.com/assets/6979137/16341743/b0312968-39fc-11e6-8e2f-2fddae5b97ec.png">

*After*

<img width="1114" alt="hero - after" src="https://cloud.githubusercontent.com/assets/6979137/16341745/b3c1ac7e-39fc-11e6-8c5c-f1b367aa1158.png">

<img width="379" alt="screen shot 2016-06-24 at 11 14 00 am" src="https://cloud.githubusercontent.com/assets/6979137/16341763/c9de9738-39fc-11e6-938b-395e24b79f7f.png">

/cc @underdogio/engineering 
