### PR TITLE
Hide overflowing text in list headings

### DIFF
--- a/docs/dropdown-menu.md
+++ b/docs/dropdown-menu.md
@@ -8,7 +8,7 @@ they should only be used within elements that have their `position` property set
 <div style="position: relative; margin-bottom: 300px; width: 300px;">
   <div class="dropdown-menu">
     <div class="dropdown-menu__wrapper">
-      <span class="list-heading">chris@underdog.io</span>
+      <span class="list-heading">chrishasasuperlongname@underdog.io</span>
       <div class="dropdown-menu__content">
         <ul class="menu-list">
           <li class="menu-list__item">
@@ -29,7 +29,7 @@ they should only be used within elements that have their `position` property set
 ```html
 <div class="dropdown-menu">
   <div class="dropdown-menu__wrapper">
-    <span class="list-heading">chris@underdog.io</span>
+    <span class="list-heading">chrishasasuperlongname@underdog.io</span>
     <div class="dropdown-menu__content">
       <ul class="menu-list">
         <li class="menu-list__item">

--- a/scss/underdog/components/_list-heading.scss
+++ b/scss/underdog/components/_list-heading.scss
@@ -6,5 +6,7 @@
   color: $list-heading-color;
   display: block;
   font-weight: $list-heading-font-weight;
+  overflow-x: hidden;
   padding: $list-heading-padding;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
Hides overflowing text in `.list-heading`.

*Before*

![screenshot 2016-06-24 11 24 23](https://cloud.githubusercontent.com/assets/6979137/16342300/63b5bb6e-39ff-11e6-8b76-2f8a8da1a32a.png)

*After*

<img width="380" alt="screen shot 2016-06-24 at 11 32 09 am" src="https://cloud.githubusercontent.com/assets/6979137/16342292/4f99ab40-39ff-11e6-908f-66c3356c4a53.png">

/cc @underdogio/engineering 