### PR TITLE
Style active nav links

### DIFF
--- a/docs/nav-list.md
+++ b/docs/nav-list.md
@@ -6,7 +6,7 @@ A nav list is a list of links to other pages within a site or application.
 
 <ul class="nav-list">
   <li class="nav-list__item">
-    <a class="nav-list__link" href="#">
+    <a class="nav-list__link nav-list__link--active" href="#">
       Item One
     </a>
   </li>
@@ -30,7 +30,7 @@ A nav list is a list of links to other pages within a site or application.
 ```html
 <ul class="nav-list">
   <li class="nav-list__item">
-    <a class="nav-list__link" href="#">
+    <a class="nav-list__link nav-list__link--active" href="#">
       Item One
     </a>
   </li>
@@ -62,7 +62,7 @@ Example within a header:
   <nav class="header__nav">
     <ul class="nav-list">
       <li class="nav-list__item">
-        <a class="nav-list__link" href="#">
+        <a class="nav-list__link nav-list__link--active" href="#">
           Item One
         </a>
       </li>
@@ -94,7 +94,7 @@ Example within a header:
   <nav class="header__nav">
     <ul class="nav-list">
       <li class="nav-list__item">
-        <a class="nav-list__link" href="#">
+        <a class="nav-list__link nav-list__link--active" href="#">
           Item One
         </a>
       </li>

--- a/scss/underdog/components/_nav-list.scss
+++ b/scss/underdog/components/_nav-list.scss
@@ -37,6 +37,8 @@
     width: 100%;
   }
 
+  &.nav-list__link--active,
+  &:focus,
   &:hover {
     &:after {
       opacity: 1;


### PR DESCRIPTION
Adds a modifier for styling "active" nav links.

<img width="554" alt="screen shot 2016-06-24 at 12 50 51 pm" src="https://cloud.githubusercontent.com/assets/6979137/16344393/5310b9e8-3a0a-11e6-9b07-32ca379af51e.png">

/cc @underdogio/engineering 