### PR TITLE
Add helper for clipping text

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -101,3 +101,19 @@ span multiple elements.
   Vehicula cillum illum reprehenderit! Laboriosam sapiente? Urna ullamcorper donec eleifend.
 </span>
 ```
+
+## Text clip
+
+Hides overflowing text.
+
+Note that this will only work with `block` level elements.
+
+<div class="text-clip border--top border--right border--bottom border--left" style="width: 100px;">
+  <span>chrishasasuperlongname@underdogiscool.com</span>
+</div>
+
+```html
+<div class="text-clip">
+  ...
+</div>
+```

--- a/scss/underdog/components/_list-heading.scss
+++ b/scss/underdog/components/_list-heading.scss
@@ -2,11 +2,10 @@
 // <span class="list-heading">Menu title</span>
 // <ul>...</ul>
 .list-heading {
+  @extend .text-clip;
   border-bottom: $list-heading-border;
   color: $list-heading-color;
   display: block;
   font-weight: $list-heading-font-weight;
-  overflow-x: hidden;
   padding: $list-heading-padding;
-  text-overflow: ellipsis;
 }

--- a/scss/underdog/generic/_helper.scss
+++ b/scss/underdog/generic/_helper.scss
@@ -104,3 +104,9 @@
     z-index: 1;
   }
 }
+
+// Hide overflowing text
+.text-clip {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
Adds a helper class `.text-clip` for hiding text overflow.

<img width="389" alt="screen shot 2016-06-24 at 1 01 12 pm" src="https://cloud.githubusercontent.com/assets/6979137/16344681/c16c39d4-3a0b-11e6-85c4-7fcac4c9dd7c.png">

/cc @underdogio/engineering 