### PR TITLE
Make buttons bold and decrease letter spacing

### DIFF
--- a/scss/underdog/mixins/_all-caps.scss
+++ b/scss/underdog/mixins/_all-caps.scss
@@ -1,4 +1,4 @@
 @mixin all-caps {
-  letter-spacing: 0.1em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
 }

--- a/scss/underdog/objects/_buttons.scss
+++ b/scss/underdog/objects/_buttons.scss
@@ -25,6 +25,7 @@
   cursor: pointer;
   display: inline-block;
   font-size: $btn-font-size;
+  font-weight: $btn-font-weight;
   padding: $btn-padding;
   text-align: center;
   text-decoration: none;

--- a/scss/underdog/variables/_buttons.scss
+++ b/scss/underdog/variables/_buttons.scss
@@ -1,5 +1,6 @@
 // Button sizing
 $btn-font-size: 12px;
+$btn-font-weight: $font-weight-bold;
 $btn-large-font-size: $gamma-font-size;
 $btn-padding: 12px 30px;
 $btn-padding-small: 12px 4px;


### PR DESCRIPTION
Closes #199 

Makes buttons bold and decreases letter spacing for the `.all-caps` helper.

This PR also affects other elements that have all-caps applied (like small headings). If this is not desired than I can go back and decrease letter spacing just for buttons.

**Buttons**

*Before*

<img width="1680" alt="buttons - before" src="https://cloud.githubusercontent.com/assets/6979137/16387320/5bc395c4-3c62-11e6-9d36-4f55c416aac2.png">

*After*

<img width="1680" alt="buttons - after" src="https://cloud.githubusercontent.com/assets/6979137/16387318/590b3abc-3c62-11e6-9a07-71369a40e689.png">

**Slabs**

*Before*

<img width="1680" alt="slab - before" src="https://cloud.githubusercontent.com/assets/6979137/16387310/526423b8-3c62-11e6-81c6-17c25cc19d70.png">

*After*

<img width="1680" alt="slab - after" src="https://cloud.githubusercontent.com/assets/6979137/16387306/4c4e228a-3c62-11e6-8ebc-c3da1b8c1111.png">

/cc @underdogio/engineering 