### PR TITLE
Reset button font weight within nav lists

### DIFF
--- a/scss/underdog/components/_nav-list.scss
+++ b/scss/underdog/components/_nav-list.scss
@@ -1,5 +1,9 @@
 .nav-list {
   display: block;
+
+  .btn {
+    font-weight: inherit;
+  }
 }
 
 .nav-list__item {


### PR DESCRIPTION
Removes the bold font weight from buttons within a nav list.

*Before*

<img width="1114" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16390141/3db29898-3c6f-11e6-926a-db51fdf1d42f.png">

*After*

<img width="1113" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/16390143/40aced5a-3c6f-11e6-8c20-a830f8eb0d62.png">

/cc @underdogio/engineering 