### PR TITLE
Apply heading styles to heading classes

### DIFF
--- a/docs/typography.md
+++ b/docs/typography.md
@@ -49,3 +49,13 @@ Typography, the foundation of every design system.
 ```html
 <span class="small-heading">Small Heading</span>
 ```
+
+## Heading classes
+
+You can apply a heading style to a non-header element with a class.
+
+<span class="h3">A span with h3 styling</span>
+
+```html
+<span class="h3">A span with h3 styling</span>
+```

--- a/scss/underdog/base/_headings.scss
+++ b/scss/underdog/base/_headings.scss
@@ -1,14 +1,34 @@
 h1,
+.h1,
 h2,
+.h2,
 h3,
+.h3,
 h4,
+.h4,
 h5,
-h6 {
+.h5,
+h6,
+.h6 {
   color: $subheader-color;
   font-weight: $font-weight-normal;
 }
 
-h1 {
+// Match font sizes for heading classes
+.h1 {
+  @extend .alpha;
+}
+
+.h2 {
+  @extend .beta;
+}
+
+.h3 {
+  @extend .gamma;
+}
+
+h1,
+.h1 {
   color: $headline-color;
 }
 


### PR DESCRIPTION
Adds heading styles to heading classes, like `.h1`, `.h2`, `.h3`, etc.

<img width="467" alt="screen shot 2016-07-08 at 10 50 24 am" src="https://cloud.githubusercontent.com/assets/6979137/16691256/ee46f8a6-44f9-11e6-86be-c262d5be81f0.png">

/cc @underdogio/engineering 