### PR TITLE
Use lighter color for dropdown menu background

### DIFF
--- a/scss/underdog/_variables.scss
+++ b/scss/underdog/_variables.scss
@@ -35,7 +35,7 @@
 @import 'variables/wrapper';
 
 // Component variables
-@import 'variables/dropdown-menu';
+@import 'variables/dropdown';
 @import 'variables/header';
 @import 'variables/list-heading';
 @import 'variables/menu-drawer';

--- a/scss/underdog/components/_dropdown.scss
+++ b/scss/underdog/components/_dropdown.scss
@@ -17,19 +17,37 @@
   width: $dropdown-menu-width;
   z-index: layer(dropdown-menu);
 
+
+  // Fake a border-ed triangle by positioning a smaller triangle with a lighter
+  // background on top of a triangle with a dark background
   &:before {
-    @include triangle($dropdown-menu-bg, $dropdown-menu-triangle-size);
+    @include triangle($dropdown-border-color, $dropdown-menu-triangle-size);
     content: '';
     display: inline-block;
 
     // Magic numbers
     margin-bottom: -0.5em;
     margin-right: 1em;
+    position: relative;
+    z-index: 0;
+  }
+
+  &:after {
+    @include triangle($dropdown-menu-bg, 12px);
+    content: '';
+    display: inline-block;
+
+    // Magic numbers
+    position: absolute;
+    right: 16px;
+    top: 11.4px;
+    z-index: 1;
   }
 }
 
 .dropdown__menu-wrapper {
   background: $dropdown-menu-bg;
+  border: $dropdown-menu-border;
   border-radius: $dropdown-menu-border-radius;
   box-shadow: $dropdown-menu-box-shadow;
   text-align: left;

--- a/scss/underdog/variables/_dropdown.scss
+++ b/scss/underdog/variables/_dropdown.scss
@@ -1,7 +1,8 @@
-$dropdown-menu-border: solid 1px $gray-xdc;
+$dropdown-border-color: $gray-xdc;
+$dropdown-menu-border: solid 1px $dropdown-border-color;
 $dropdown-menu-box-shadow: 0 2px 2px $gray-xdc;
 $dropdown-menu-border-radius: 4px;
-$dropdown-menu-bg: $gray-xf3 !default;
+$dropdown-menu-bg: $white !default;
 $dropdown-menu-content-padding: $base-spacing-unit !default;
-$dropdown-menu-triangle-size: 1em;
+$dropdown-menu-triangle-size: 14px;
 $dropdown-menu-width: 16em;


### PR DESCRIPTION
Closes #207 

Removes the gray background color from dropdown menus.

**Before**

<img width="238" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16715719/2488f2e4-46b6-11e6-9ec7-6752930e9dd1.png">

**After**

<img width="253" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/16715717/20734768-46b6-11e6-900b-1e016bd6df10.png">


/cc @underdogio/engineering @cmuir 