### PR TITLE
Conform Google button styling to Google's guidelines

### DIFF
--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -60,14 +60,16 @@ Secondary buttons.
 
 <div class="row">
   <div class="col-3-medium-and-up col-6-small">
-    <button class="btn btn--google">G+ Sign in with Google</button>
+    <button class="btn btn--google">Sign in with Google</button>
+  </div>
+  <div class="col-3-medium-and-up col-6-small">
+    <button class="btn btn--google btn--disabled">Sign in with Google</button>
   </div>
 </div>
 
-Google button.
-
 ```html
-<button class="btn btn--secondary">G+ Sign in with Google</button>
+<button class="btn btn--google">Sign in with Google</button>
+<button class="btn btn--google btn--disabled">Sign in with Google</button>
 ```
 
 ## Link as a button

--- a/scss/underdog/objects/_buttons.scss
+++ b/scss/underdog/objects/_buttons.scss
@@ -105,9 +105,36 @@
   @include button-disabled($btn-danger-disabled-bg, $btn-danger-disabled-color);
 }
 
-// Google sign in button
+// Google sign in button. Most conform to Google's guidelines.
+// SEE: https://developers.google.com/identity/branding-guidelines
 .btn--google {
   @include button-variant($btn-google-bg, $btn-google-color);
+  @include button-disabled($btn-primary-disabled-bg, $btn-primary-disabled-color);
+  padding-left: 5.25em;
+  position: relative;
+
+  &:before {
+    background-color: $white;
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAMAAAC5zwKfAAAB/lBMVEUAAAD///////////////////////////80qFM1p1k2qVQ2qVU5qlc6mZY6q1g9kbs9pHY9qVA+rFw/qGw/rVxAi9hBrV5ChfRChvBDhfREhvRFr2FHiPRIsWRLi/VMsmdRj/VSq0dUkPVXk/VXt3FZuHJclvZel/Zhu3limvZpnvZswIJxwoZ0pfd0rjp4xY15xo58x5CAyJOCrviCsuqDypaJzZuQ0KGU0aSU0aWW0qaY06iZvfma06Sb1Kugsyigwvmm2bOn2bSox/qz3r61tSG91PvB5MrD5czE5s3F5s7H2/zH3PvJ6NHK6NLO6tbY5v3ZuRLh8uXi8ubqQzXqRDbqRTfqRznqRzrq8v7q9u3rSDPrTDzrTD/rTUDrT0LrUEPsVUjsVUnsWU3tVi7tYFTuZFnwaiXwuwnw+fLxfnTxgnfxgnjxg3rxhXzyiH/yjYTyjYXzhRvzkYnzkor0mZH0mnz0m5P0npb1kRb1o5z2rKb2r6n3s633ubT4qA34wLz5x8P5yMT5ycX5+//5/Pr5/fr6tgf608/7vAX7vQr7wh372db72df7/fz8xy784uD84+H85OL8/vz912r92nX934f97Or98fD9/v7+56X+8Mf+89H+8/L+9Nb+9Nf++Pj++vn+//7+////+/v//Pz//f3//vv//vz///8OXBpUAAAACHRSTlMADoKDu8jb3PqA2iUAAAHcSURBVHgB7dhXcxJRFMBxgQWvir2svfdeFLsi9o66Yu9FsXdRUkjPpveQhJSElJxvmexl78wu8MK594HJ3P/befnNMOzOnjnT8jaZw6W4uVJcDps3HbjzWEUXCMhpARURoGIB3SJAtwQlKEEJ5hk43FQS/fktUlA9KgTs/PtMM3v+pY4bbPl6T7P2oZkPLHuqpfUkxgNGQ1pGd+vx4G8ti1cIaLBUY91/+/nTmxDzsGD8hcm9Khox5oHYS+qhwY+mFxkEs97v1EOCiX+PqPdf1JvSrhe/nvR+gSBwvFbXq95pj+OiwB7d6McfEAV267R+Nm+xdSB3sIN6NWNsVm1tzh1so2AjZAdXiwaXJQX/5LXoP6UvO7gN+9icPsnmoNl2Cu7CPdjvd5MFYbD1YDkF/ahX79Y6QogPbPlVWhABJs7PJ0anwNLVldRbn0SAsIekOlYJrGspTz0LGDC8yhTXnGsFo5s7Fy6m3oZyFAiXCcu7ce++rSsIITPmGuAF7EfqMMls9lL1BP4zGpiVKc47mMSDcGVRujfzeBfXKnJnv9fmbbrBvSw9PLKEaXN2XBwSsc413L4U8B06euZ6xdTeYCUoQQlKUPy5T/xB0uEReTKlopP3qOukXl4mmwCTzwLBp5ZKJwAAAABJRU5ErkJggg==);
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    border-radius: $btn-border-radius;
+    content: '';
+    display: block;
+    height: calc(100% - 2px);
+    left: 1px;
+    position: absolute;
+    top: 1px;
+    width: 3.25em;
+  }
+
+  &.btn--disabled {
+    &:before {
+      filter: grayscale(100%);
+      opacity: 0.5;
+    }
+  }
 }
 
 // Button group

--- a/scss/underdog/variables/_buttons.scss
+++ b/scss/underdog/variables/_buttons.scss
@@ -19,7 +19,7 @@ $btn-secondary-color: $text-color;
 $btn-secondary-border-color: $gray-xdc;
 $btn-secondary-disabled-bg: $white;
 $btn-secondary-disabled-color: $gray-xdc;
-$btn-google-bg: $google-red;
+$btn-google-bg: $google-blue;
 $btn-google-color: $white;
 $btn-hover-darken: 7%;
 

--- a/scss/underdog/variables/_colors.scss
+++ b/scss/underdog/variables/_colors.scss
@@ -26,7 +26,7 @@ $linkedin-blue: #2476B9; // LinkedIn icon
 $visa-yellow: #E9A631; // Visa icon
 
 // Third party branding colors
-$google-red: #DC4E41; // Google sign in button
+$google-blue: #4285F4; // Google sign in button
 
 // Transparent colors
 $semi-transparent: rgba($black, 0.2);


### PR DESCRIPTION
Closes #181 

Updates the Google Sign In Button to be more in-line with Google's own guidelines.

**Before** 

<img width="594" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16738335/46bc4bec-4763-11e6-95a8-b4097714e479.png">

**After**

<img width="668" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/16738343/49733008-4763-11e6-94e6-d0feabacb2d1.png">

**Example screenshot from Google's guidelines**

<img width="269" alt="screen shot 2016-07-11 at 12 30 51 pm" src="https://cloud.githubusercontent.com/assets/6979137/16738355/52b60f1e-4763-11e6-9d4f-be5241f8661b.png">

The Google logo is incorporated as a base 64 encoded image. This would normally be a big no-no, but since the image is so small and is being used in just one place, I'm okay with it being used here.

/cc @underdogio/engineering 