### PR TITLE
Make list headings black

### DIFF
--- a/scss/underdog/variables/_list-heading.scss
+++ b/scss/underdog/variables/_list-heading.scss
@@ -1,4 +1,4 @@
-$list-heading-color: $light-purple !default;
+$list-heading-color: $text-color !default;
 $list-heading-font-weight: $font-weight-bold;
 $list-heading-padding: $half-spacing-unit $base-spacing-unit !default;
 $list-heading-border: 1px solid $gray-xdc;


### PR DESCRIPTION
Updates `.list-heading` to be `#444` instead of purple.

*Before*

<img width="263" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16773554/6176fdce-4826-11e6-9160-ee9c0a00b233.png">

*After*

<img width="290" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/16773546/5ec1e47c-4826-11e6-845e-dc0d6a7aa6ff.png">

/cc @underdogio/engineering 