### PR TITLE
Allow row-max-width variable to be overridden

### DIFF
--- a/scss/underdog/variables/_grid.scss
+++ b/scss/underdog/variables/_grid.scss
@@ -5,4 +5,4 @@ $double-spacing-width: 28px !default;
 // Grid
 $columns: 12;
 $gutter-width: $base-spacing-width !default;
-$row-max-width: 1400px;
+$row-max-width: 1400px !default;


### PR DESCRIPTION
Let's us set a separate `max-width` for `.container` in other projects.

/cc @underdogio/engineering 