### PR TITLE
Add page-header component

### DIFF
--- a/docs/page-header.md
+++ b/docs/page-header.md
@@ -1,0 +1,33 @@
+---
+title: Page Header
+---
+
+Page headers are used to headline a page of content.
+
+<header class="page-header">
+  <h1 class="page-header__title">About us</h1>
+</header>
+
+```html
+<header class="page-header">
+  <h1 class="page-header__title">About us</h1>
+</header>
+```
+
+Page headers can also have a bottom border and a subtitle.
+
+<div class="page-header page-header--bordered">
+  <h1 class="page-header__title">Candidate application</h1>
+  <p class="page-header__subtitle">
+    This is the only information that we need from you. We promise.
+  </p>
+</div>
+
+```html
+<div class="page-header page-header--bordered">
+  <h1 class="page-header__title">Candidate application</h1>
+  <p class="page-header__subtitle">
+    This is the only information that we need from you. We promise.
+  </p>
+</div>
+```

--- a/scss/underdog/_underdog.scss
+++ b/scss/underdog/_underdog.scss
@@ -25,6 +25,7 @@
 @import 'components/menu-list';
 @import 'components/modal';
 @import 'components/nav-list';
+@import 'components/page-header';
 @import 'components/section-divider';
 @import 'components/sidebar';
 @import 'components/slab';

--- a/scss/underdog/_variables.scss
+++ b/scss/underdog/_variables.scss
@@ -43,6 +43,7 @@
 @import 'variables/modal';
 @import 'variables/nav-list';
 @import 'variables/opacity';
+@import 'variables/page-header';
 @import 'variables/section-divider';
 @import 'variables/slab';
 @import 'variables/spinner';

--- a/scss/underdog/components/_page-header.scss
+++ b/scss/underdog/components/_page-header.scss
@@ -1,0 +1,26 @@
+.page-header {
+  margin-bottom: $page-header-spacing;
+}
+
+.page-header__title {
+  font-weight: $page-header-font-weight;
+  margin-bottom: $page-header-title-spacing;
+
+  &:only-child {
+    // Remove spacing if title is only the only elements
+    margin-bottom: 0;
+  }
+}
+
+.page-header__subtitle {
+  margin-bottom: 0;
+}
+
+.page-header--bordered {
+  border-bottom: $page-header-border;
+
+  .page-header__subtitle {
+    // Add spacing between subtitle and border
+    margin-bottom: $page-header-subtitle-spacing;
+  }
+}

--- a/scss/underdog/variables/_page-header.scss
+++ b/scss/underdog/variables/_page-header.scss
@@ -1,0 +1,5 @@
+$page-header-border: 2px solid $border-color;
+$page-header-font-weight: $font-weight-bold;
+$page-header-spacing: $base-spacing-unit * 2;
+$page-header-subtitle-spacing: $base-spacing-unit;
+$page-header-title-spacing: $half-spacing-unit;


### PR DESCRIPTION
Adds a component for headlining some content.

[An example from Zeplin](https://app.zeplin.io/project.html#pid=5783eecf83b2efb85b3757e7&sid=5783ef476b4351d34468c3f2)

Screenshot from styleguide:

<img width="1301" alt="screen shot 2016-07-12 at 1 53 02 pm" src="https://cloud.githubusercontent.com/assets/6979137/16777548/fbae7690-4837-11e6-8fe0-93bca43df003.png">

/cc @underdogio/engineering 