### PR TITLE
Use #777 for color--gray helper

### DIFF
--- a/scss/underdog/generic/_helper.scss
+++ b/scss/underdog/generic/_helper.scss
@@ -21,7 +21,7 @@
 }
 
 .color--gray {
-  color: $gray-xdc;
+  color: $light-gray;
 }
 
 .color--orange {


### PR DESCRIPTION
The `.color--gray` helper was using a color that was way too hard to read. This PR remedies that.

*Before*

<img width="114" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16813637/7d0a1ab4-4900-11e6-846d-86219172a92a.png">

*After*

<img width="113" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/16813634/79e093c2-4900-11e6-9a02-48d270c46bbc.png">


/cc @underdogio/engineering 