### PR TITLE
Add longform object

### DIFF
--- a/docs/layout/longform.md
+++ b/docs/layout/longform.md
@@ -1,0 +1,73 @@
+---
+title: Longform
+category: Layout
+---
+
+Use `.longform` to make long forms look less intimidating.
+
+<form class="longform">
+  <div class="longform__col">
+    <label>
+      <span class="block-label">
+        Company name
+      </span>
+      <input class="block-input" type="text" required />
+    </label>
+    <label>
+      <span class="block-label">
+        Website
+      </span>
+      <input class="block-input" type="url" required />
+    </label>
+  </div>
+  <div class="longform__col">
+    <label>
+      <span class="block-label">
+        Email address
+      </span>
+      <input class="block-input" type="email" required />
+    </label>
+    <label>
+      <span class="block-label">
+        Your name
+      </span>
+      <input class="block-input" type="text" required />
+    </label>
+    <button class="btn btn--primary float--right">Sign Up</button>
+  </div>
+</form>
+
+```html
+
+<form class="longform">
+  <div class="longform__col">
+    <label>
+      <span class="block-label">
+        Company name
+      </span>
+      <input class="block-input" type="text" required />
+    </label>
+    <label>
+      <span class="block-label">
+        Website
+      </span>
+      <input class="block-input" type="url" required />
+    </label>
+  </div>
+  <div class="longform__col">
+    <label>
+      <span class="block-label">
+        Email address
+      </span>
+      <input class="block-input" type="email" required />
+    </label>
+    <label>
+      <span class="block-label">
+        Your name
+      </span>
+      <input class="block-input" type="text" required />
+    </label>
+    <button class="btn btn--primary float--right">Sign Up</button>
+  </div>
+</form>
+```

--- a/scss/underdog/_underdog.scss
+++ b/scss/underdog/_underdog.scss
@@ -13,6 +13,7 @@
 @import 'objects/hero';
 @import 'objects/icons';
 @import 'objects/links';
+@import 'objects/longform';
 @import 'objects/section';
 @import 'objects/wrapper';
 

--- a/scss/underdog/_variables.scss
+++ b/scss/underdog/_variables.scss
@@ -31,6 +31,7 @@
 @import 'variables/hero';
 @import 'variables/icons';
 @import 'variables/links';
+@import 'variables/longform';
 @import 'variables/section';
 @import 'variables/wrapper';
 

--- a/scss/underdog/objects/_longform.scss
+++ b/scss/underdog/objects/_longform.scss
@@ -1,0 +1,17 @@
+.longform {
+  @extend .cf;
+  max-width: $longform-max-width;
+}
+
+.longform__col {
+  @include media-query-large-and-up {
+    float: left;
+    padding-right: $longform-col-padding / 2;
+    width: 50%;
+
+    & + & {
+      padding-left: $longform-col-padding / 2;
+      padding-right: 0;
+    }
+  }
+}

--- a/scss/underdog/variables/_longform.scss
+++ b/scss/underdog/variables/_longform.scss
@@ -1,0 +1,2 @@
+$longform-max-width: 800px !default;
+$longform-col-padding: $base-spacing-width * 4 !default;


### PR DESCRIPTION
Adds a `.longform` object that can be used to break up large forms into columns.

Design from Zeps: https://app.zeplin.io/project.html#pid=5783eecf83b2efb85b3757e7&sid=5783ef462160e20209b3cd30

Screenshots:

**Default**

<img width="855" alt="screen shot 2016-07-18 at 12 40 36 pm" src="https://cloud.githubusercontent.com/assets/6979137/16922744/f232e144-4ce4-11e6-922d-76ec247bc99b.png">

**Collapsed**

<img width="560" alt="screen shot 2016-07-18 at 12 41 04 pm" src="https://cloud.githubusercontent.com/assets/6979137/16922741/eef207b2-4ce4-11e6-9583-9e990582142d.png">

/cc @underdogio/engineering 