### PR TITLE
Add footer component

### DIFF
--- a/docs/components/footer.md
+++ b/docs/components/footer.md
@@ -1,0 +1,28 @@
+---
+title: Footer
+category: Components
+---
+
+<footer class="footer">
+  <nav>
+    <a class="footer__link" href="#">Blog</a>
+    <a class="footer__link" href="#">Terms</a>
+    <a class="footer__link" href="#">Facebook</a>
+  </nav>
+  <span>
+    &copy; 2014-2016 Porter Labs Inc. All Rights Reserved.
+  </span>
+</footer>
+
+```html
+<footer class="footer">
+  <nav>
+    <a class="footer__link" href="#">Blog</a>
+    <a class="footer__link" href="#">Terms</a>
+    <a class="footer__link" href="#">Facebook</a>
+  </nav>
+  <span>
+    &copy; 2014-2016 Porter Labs Inc. All Rights Reserved.
+  </span>
+</footer>
+```

--- a/scss/underdog/_underdog.scss
+++ b/scss/underdog/_underdog.scss
@@ -20,6 +20,7 @@
 // Underdog specific components
 @import 'components/content-header';
 @import 'components/dropdown';
+@import 'components/footer';
 @import 'components/header';
 @import 'components/list-heading';
 @import 'components/menu-drawer';

--- a/scss/underdog/_variables.scss
+++ b/scss/underdog/_variables.scss
@@ -37,6 +37,7 @@
 
 // Component variables
 @import 'variables/dropdown';
+@import 'variables/footer';
 @import 'variables/header';
 @import 'variables/list-heading';
 @import 'variables/menu-drawer';

--- a/scss/underdog/components/_footer.scss
+++ b/scss/underdog/components/_footer.scss
@@ -1,0 +1,32 @@
+.footer {
+  border-top: $footer-border;
+  color: $footer-color;
+  font-weight: $footer-font-weight;
+  padding: $footer-padding;
+
+  @include media-query-small {
+    text-align: center;
+  }
+
+  @include media-query-medium-and-up {
+    align-items: flex-start;
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+.footer__link {
+  color: inherit;
+  font-weight: inherit;
+  text-decoration: none;
+
+  @include media-query-small {
+    display: block;
+    margin-bottom: $footer-link-spacing;
+  }
+
+  @include media-query-medium-and-up {
+    display: inline-block;
+    margin-right: $footer-link-spacing;
+  }
+}

--- a/scss/underdog/variables/_footer.scss
+++ b/scss/underdog/variables/_footer.scss
@@ -1,0 +1,5 @@
+$footer-border: $border-width solid $border-color;
+$footer-color: $light-gray;
+$footer-font-weight: $font-weight-bold;
+$footer-link-spacing: $base-spacing-width;
+$footer-padding: $half-spacing-unit 0;


### PR DESCRIPTION
Adds a footer component.

Design from Zeps: https://app.zeplin.io/project.html#pid=5783eecf83b2efb85b3757e7&sid=5783ef4783b2efb85b375afb

The border width needs to be increased from `1px` to `2px`, but that will come in another PR.

Screenshots:

**Wide viewport**

<img width="1146" alt="screen shot 2016-07-18 at 2 18 22 pm" src="https://cloud.githubusercontent.com/assets/6979137/16925553/cbd6a824-4cf2-11e6-9c85-b1bf58972532.png">

**Narrow viewport**

<img width="319" alt="screen shot 2016-07-18 at 2 19 02 pm" src="https://cloud.githubusercontent.com/assets/6979137/16925565/d0292140-4cf2-11e6-933d-4b713477215d.png">

/cc @underdogio/engineering 