### PR TITLE
Update default border width to 2px

### DIFF
--- a/scss/underdog/variables/_borders.scss
+++ b/scss/underdog/variables/_borders.scss
@@ -1,5 +1,5 @@
 // Define borders
-$border-width: 4px;
+$border-width: 2px;
 $border-width-thin: 1px;
 
 $border-color: $gray-xf3;


### PR DESCRIPTION
Makes the default border width less thick.

**Aside layout borders**

*Before*

<img width="1680" alt="thiq" src="https://cloud.githubusercontent.com/assets/6979137/16925907/707a27c4-4cf4-11e6-87aa-09671d0267ac.png">

*After*

<img width="1677" alt="screen shot 2016-07-18 at 2 25 05 pm" src="https://cloud.githubusercontent.com/assets/6979137/16925898/6b223578-4cf4-11e6-9596-59a71c6bd82f.png">

**Slabs**

*Before*

<img width="1121" alt="slab - thiq" src="https://cloud.githubusercontent.com/assets/6979137/16925877/51dde01c-4cf4-11e6-8458-4cf3f5424448.png">

*After*

<img width="1118" alt="slab - thin" src="https://cloud.githubusercontent.com/assets/6979137/16925879/55d5e96c-4cf4-11e6-9057-762bc0c369f3.png">

/cc @underdogio/engineering @cmuir 