### PR TITLE
Allow header content to be resized

### DIFF
--- a/docs/components/header.md
+++ b/docs/components/header.md
@@ -14,24 +14,6 @@ To make a header sticky, apply the `.header--fixed` modifier class to it.
   <div class="header__nav">
     <div class="hidden--small"><span class="gamma push10--right">Lionel Itchy</span><span class="icon icon-arrow"></span></div>
     <div class="hidden--medium-and-up"><span class="icon icon-menu" aria-hidden="true"></span><span class="gamma"> Menu</span></div>
-    <div class="dropdown-menu">
-      <div class="dropdown-menu__wrapper">
-        <span class="list-heading">chris@underdog.io</span>
-        <div class="dropdown-menu__content">
-          <ul class="menu-list">
-            <li class="menu-list__item">
-              <a class="nav-link" href="/settings/">Settings</a>
-            </li>
-            <li class="menu-list__item">
-              <a class="nav-link" href="/support/">Support</a>
-            </li>
-            <li class="menu-list__item">
-              <a class="nav-link" href="/logout/">Log out</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 
@@ -42,24 +24,41 @@ To make a header sticky, apply the `.header--fixed` modifier class to it.
     <img class="hidden--medium-and-up" src="/dist/img/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
   </div>
   <div class="header__nav">
-    <span>Lionel Itchy</span>
-    <span class="icon icon-arrow" />
-    <div class="dropdown-menu">
-      <div class="dropdown-menu__wrapper">
-        <span class="list-heading">chris@underdog.io</span>
-        <div class="dropdown-menu__content">
-          <ul class="menu-list">
-            <li class="menu-list__item">
-              <a class="nav-link" href="/settings/">Settings</a>
-            </li>
-            <li class="menu-list__item">
-              <a class="nav-link" href="/support/">Support</a>
-            </li>
-            <li class="menu-list__item">
-              <a class="nav-link" href="/logout/">Log out</a>
-            </li>
-          </ul>
-        </div>
+    <div class="hidden--small"><span class="gamma push10--right">Lionel Itchy</span><span class="icon icon-arrow"></span></div>
+    <div class="hidden--medium-and-up"><span class="icon icon-menu" aria-hidden="true"></span><span class="gamma"> Menu</span></div>
+  </div>
+</div>
+```
+
+The content of the header can be restricted by wrapping it within an optional `.header__content`
+element and overriding the value for the `$header-max-width` Sass variable:
+
+<div class="header">
+  <div class="header__content" style="flex-basis: 800px;">
+    <div class="header__logo">
+      <img class="hidden--small" src="/dist/img/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
+      <img class="hidden--medium-and-up" src="/dist/img/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
+    </div>
+    <div class="header__nav">
+      <div class="header__nav">
+        <div class="hidden--small"><span class="gamma push10--right">Lionel Itchy</span><span class="icon icon-arrow"></span></div>
+        <div class="hidden--medium-and-up"><span class="icon icon-menu" aria-hidden="true"></span><span class="gamma"> Menu</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="header">
+  <div class="header__content">
+    <div class="header__logo">
+      <img class="hidden--small" src="/dist/img/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
+      <img class="hidden--medium-and-up" src="/dist/img/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
+    </div>
+    <div class="header__nav">
+      <div class="header__nav">
+        <div class="hidden--small"><span class="gamma push10--right">Lionel Itchy</span><span class="icon icon-arrow"></span></div>
+        <div class="hidden--medium-and-up"><span class="icon icon-menu" aria-hidden="true"></span><span class="gamma"> Menu</span></div>
       </div>
     </div>
   </div>

--- a/scss/underdog/components/_header.scss
+++ b/scss/underdog/components/_header.scss
@@ -11,13 +11,25 @@
 // </div>
 // ======
 
-.header {
+// Allow header__content to be optional
+.header,
+.header__content {
   align-items: center;
-  background: $header-bg;
-  color: $header-color;
   display: flex;
   justify-content: space-between;
+}
+
+.header {
+  background: $header-bg;
+  color: $header-color;
   padding: $header-padding;
+}
+
+.header__content {
+  left: 50%;
+  flex: 0 0 $header-max-width;
+  position: relative;
+  transform: translateX(-50%);
 }
 
 .header__logo {

--- a/scss/underdog/variables/_header.scss
+++ b/scss/underdog/variables/_header.scss
@@ -1,4 +1,5 @@
 // Header coloring
 $header-bg: $white;
 $header-color: $whitish-black;
+$header-max-width: 100% !default;
 $header-padding: $quarter-spacing-unit 0;

--- a/server/views/partials/header.hbs
+++ b/server/views/partials/header.hbs
@@ -1,35 +1,37 @@
 <nav class="header">
-  <a class="header__logo" href="/">
-    <img class="hidden--medium-and-down" src="/dist/img/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
-    <img class="hidden--large-and-up" src="/dist/img/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
-  </a>
-  <div class="header__nav">
-    <ul class="nav-list">
-      <li class="nav-list__item">
-        <span class="nav-list__link media-query" data-width="530" role="button">
-          Small (530)
-        </span>
-      </li>
-      <li class="nav-list__item">
-        <span class="nav-list__link media-query" data-width="768" role="button">
-          Medium (768)
-        </span>
-      </li>
-      <li class="nav-list__item">
-        <span class="nav-list__link media-query" data-width="1024" role="button">
-          Large (1024)
-        </span>
-      </li>
-      <li class="nav-list__item">
-        <span class="nav-list__link media-query" data-width="1440" role="button">
-          Extra Large (1440)
-        </span>
-      </li>
-      <li class="nav-list__item">
-        <a class="nav-list__btn btn btn--secondary" href="https://underdog.io">
-          Underdog.io
-        </a>
-      </li>
-    </ul>
+  <div class="header__content">
+    <a class="header__logo" href="/">
+      <img class="hidden--medium-and-down" src="/dist/img/underdogio-logo-with-text.svg" alt="Underdog.io logo" width="173" height="50">
+      <img class="hidden--large-and-up" src="/dist/img/underdogio-logo.svg" alt="Underdog.io logo" width="48" height="50">
+    </a>
+    <div class="header__nav">
+      <ul class="nav-list">
+        <li class="nav-list__item">
+          <span class="nav-list__link media-query" data-width="530" role="button">
+            Small (530)
+          </span>
+        </li>
+        <li class="nav-list__item">
+          <span class="nav-list__link media-query" data-width="768" role="button">
+            Medium (768)
+          </span>
+        </li>
+        <li class="nav-list__item">
+          <span class="nav-list__link media-query" data-width="1024" role="button">
+            Large (1024)
+          </span>
+        </li>
+        <li class="nav-list__item">
+          <span class="nav-list__link media-query" data-width="1440" role="button">
+            Extra Large (1440)
+          </span>
+        </li>
+        <li class="nav-list__item">
+          <a class="nav-list__btn btn btn--secondary" href="https://underdog.io">
+            Underdog.io
+          </a>
+        </li>
+      </ul>
+    </div>
   </div>
 </nav>


### PR DESCRIPTION
Allows the content within `.header` to be constrained to a max width by introducing a new element, `.header__content`. The max width can be adjusted by setting a value for the `$header-max-width` variable.

/cc @underdogio/engineering 