### PR TITLE
Match header padding to the grid

### DIFF
--- a/scss/underdog/components/_header.scss
+++ b/scss/underdog/components/_header.scss
@@ -22,7 +22,7 @@
 .header {
   background: $header-bg;
   color: $header-color;
-  padding: $header-padding;
+  padding: $header-padding-vertical $header-padding-horizontal;
 }
 
 .header__content {
@@ -33,14 +33,16 @@
 }
 
 .header__logo {
-  @extend .push25--left;
   // Hack for removing extra spacing around <img /> tags
   // SEE: https://css-tricks.com/fighting-the-space-between-inline-block-elements/
   display: flex;
+  // Match grid column gutter
+  margin-left: ($header-padding-horizontal / 2);
 }
 
 .header__nav {
-  @extend .push25--right;
+  // Match grid column gutter
+  margin-right: ($header-padding-horizontal / 2);
   position: relative;
 }
 

--- a/scss/underdog/variables/_header.scss
+++ b/scss/underdog/variables/_header.scss
@@ -2,4 +2,5 @@
 $header-bg: $white;
 $header-color: $whitish-black;
 $header-max-width: 100% !default;
-$header-padding: $quarter-spacing-unit 0;
+$header-padding-horizontal: $base-spacing-width;
+$header-padding-vertical: $quarter-spacing-unit;


### PR DESCRIPTION
Tweaks header padding so that it will be more inline with the grid. Everything will still line up nicely whether or not a `.header__content` element is being used.

Company Dashboard before / after (header padding decreased by 7px on each side):

*Before*

<img width="1680" alt="cd - before" src="https://cloud.githubusercontent.com/assets/6979137/16958742/d2df60c6-4daf-11e6-8e91-b84f64f99c0e.png">

*After*

<img width="1679" alt="cd - after" src="https://cloud.githubusercontent.com/assets/6979137/16958753/e5c3ad96-4daf-11e6-929e-e8b6f00826af.png">

Example of `.header__content` lining up with content that is wrapped within a `.container`:

<img width="1407" alt="screen shot 2016-07-19 at 12 49 32 pm" src="https://cloud.githubusercontent.com/assets/6979137/16958674/800ac340-4daf-11e6-9204-5b855dadc85b.png">

/cc @underdogio/engineering 