### PR TITLE
Decrease section spacing

### DIFF
--- a/scss/underdog/variables/_section.scss
+++ b/scss/underdog/variables/_section.scss
@@ -1,5 +1,5 @@
 // Section spacing
-$section-spacing: $base-spacing-unit * 4 !default;
+$section-spacing: $base-spacing-unit * 2 !default;
 
 // Subsection spacing
-$subsection-spacing: $base-spacing-unit * 2 !default;
+$subsection-spacing: $base-spacing-unit !default;


### PR DESCRIPTION
Decreases section spacing (88px -> 44px) to be more inline with what is in Zeps https://app.zeplin.io/project.html#pid=5783eecf83b2efb85b3757e7&sid=5783ef4783b2efb85b375afb (about 35px between the nav and h1).

/cc @underdogio/engineering 