### PR TITLE
Tweak footer padding

### DIFF
--- a/scss/underdog/variables/_footer.scss
+++ b/scss/underdog/variables/_footer.scss
@@ -2,4 +2,4 @@ $footer-border: $border-width solid $border-color;
 $footer-color: $light-gray;
 $footer-font-weight: $font-weight-bold;
 $footer-link-spacing: $base-spacing-width;
-$footer-padding: $half-spacing-unit 0;
+$footer-padding: $base-spacing-unit 0 ($base-spacing-unit * 1.5) 0;


### PR DESCRIPTION
Tweaks footer padding to be more inline with what is in Zeps.

I added a bottom border in the following screenshots so that the bottom padding can be more visible:

*Before*

<img width="1104" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16960037/be389d08-4db5-11e6-9a4e-e586003baaa8.png">

*After*

<img width="1108" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/16960034/bbb35c62-4db5-11e6-817a-83273b478da1.png">

*From Zeplin*

<img width="1030" alt="zeps" src="https://cloud.githubusercontent.com/assets/6979137/16960031/b91c8014-4db5-11e6-8e99-8f73733aaeee.png">

/cc @underdogio/engineering 