### PR TITLE
Increase breakpoint where footer collapses

### DIFF
--- a/docs/components/footer.md
+++ b/docs/components/footer.md
@@ -7,7 +7,10 @@ category: Components
   <nav>
     <a class="footer__link" href="#">Blog</a>
     <a class="footer__link" href="#">Terms</a>
+    <a class="footer__link" href="#">Privacy</a>
+    <a class="footer__link" href="#">Twitter</a>
     <a class="footer__link" href="#">Facebook</a>
+    <a class="footer__link" href="#">Google+</a>
   </nav>
   <span>
     &copy; 2014-2016 Porter Labs Inc. All Rights Reserved.
@@ -19,7 +22,10 @@ category: Components
   <nav>
     <a class="footer__link" href="#">Blog</a>
     <a class="footer__link" href="#">Terms</a>
+    <a class="footer__link" href="#">Privacy</a>
+    <a class="footer__link" href="#">Twitter</a>
     <a class="footer__link" href="#">Facebook</a>
+    <a class="footer__link" href="#">Google+</a>
   </nav>
   <span>
     &copy; 2014-2016 Porter Labs Inc. All Rights Reserved.

--- a/scss/underdog/components/_footer.scss
+++ b/scss/underdog/components/_footer.scss
@@ -4,11 +4,11 @@
   font-weight: $footer-font-weight;
   padding: $footer-padding;
 
-  @include media-query-small {
+  @include media-query-medium-and-down {
     text-align: center;
   }
 
-  @include media-query-medium-and-up {
+  @include media-query-large-and-up {
     align-items: flex-start;
     display: flex;
     justify-content: space-between;
@@ -20,12 +20,12 @@
   font-weight: inherit;
   text-decoration: none;
 
-  @include media-query-small {
+  @include media-query-medium-and-down {
     display: block;
     margin-bottom: $footer-link-spacing;
   }
 
-  @include media-query-medium-and-up {
+  @include media-query-large-and-up {
     display: inline-block;
     margin-right: $footer-link-spacing;
   }


### PR DESCRIPTION
The breakpoint at which footer content would collapse to a single column didn't leave enough room for everything to fit on a single line for larger viewports. This PR fixes that.

I also added more links to the footer example to match up with what is going to end up in joinfetch.

/cc @underdogio/engineering 