### PR TITLE
Allow header to shrink if flex-basis is larger than viewport width

### DIFF
--- a/scss/underdog/components/_header.scss
+++ b/scss/underdog/components/_header.scss
@@ -27,7 +27,7 @@
 
 .header__content {
   left: 50%;
-  flex: 0 0 $header-max-width;
+  flex: 0 1 $header-max-width;
   position: relative;
   transform: translateX(-50%);
 }


### PR DESCRIPTION
If you use a fixed value for the flex-basis of header content, the header will not shrink if the value is greater than the width of the screen. This fix sets the `flex-shrink` property on the header content to allow it to shrink if necessary.

The `flex-basis` is set to `1200px` in the following screenshots:

*Before*

<img width="832" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/16961259/afb79d1a-4dba-11e6-9b1d-e5aacfc5069b.png">

*After*

<img width="834" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/16961266/b5e2f4aa-4dba-11e6-8a2d-9384059ff480.png">

/cc @underdogio/engineering 