### PR TITLE
Smooth font rendering for webkit browsers

### DIFF
--- a/scss/underdog/base/_body.scss
+++ b/scss/underdog/base/_body.scss
@@ -1,3 +1,7 @@
 body {
   color: $text-color;
+  // Enable font smoothing.
+  // SEE: http://caniuse.com/#feat=font-smooth
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Enables font smoothing for Safari, Chrome, and Firefox. Sorry IE HAHAHA (jk, IE gets font smoothing by default).

These screenshots are in Chrome on OS X, but the results are the same in all browsers:

*Before*

<img width="1680" alt="without" src="https://cloud.githubusercontent.com/assets/6979137/16969279/b121233e-4de1-11e6-847d-79968825b5dd.png">

*After*

<img width="1680" alt="with" src="https://cloud.githubusercontent.com/assets/6979137/16969276/ae675e1a-4de1-11e6-852a-bda1be53229c.png">

/cc @underdogio/engineering 