### PR TITLE
Remove default webkit styling from form inputs

### DIFF
--- a/scss/underdog/base/_forms.scss
+++ b/scss/underdog/base/_forms.scss
@@ -20,6 +20,7 @@ input {
     font-size: $input-text-font-size;
     margin-bottom: $input-text-spacing;
     padding: $input-text-padding;
+    -webkit-appearance: none;
   }
 
   &:hover {


### PR DESCRIPTION
Screenshots are from the Xcode iPhone simulator running iOS 9.0:

*Before*

<img width="351" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/17028204/c3813ccc-4f34-11e6-9fc6-f896453b8063.png">

*After*

<img width="343" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/17028196/bf247a36-4f34-11e6-8ce1-3adcd1217e46.png">

/cc @underdogio/engineering 