### PR TITLE
Add spacing to page header title when only child in bordered page header

### DIFF
--- a/docs/components/page-header.md
+++ b/docs/components/page-header.md
@@ -32,3 +32,15 @@ Page headers can also have a bottom border and a subtitle.
   </p>
 </div>
 ```
+
+Page header with a border but no subtitle:
+
+<div class="page-header page-header--bordered">
+  <h1 class="page-header__title">Candidate application</h1>
+</div>
+
+```html
+<div class="page-header page-header--bordered">
+  <h1 class="page-header__title">Candidate application</h1>
+</div>
+```

--- a/scss/underdog/components/_page-header.scss
+++ b/scss/underdog/components/_page-header.scss
@@ -2,6 +2,12 @@
   margin-bottom: $page-header-spacing;
 }
 
+.page-header__title,
+.page-header__subtitle {
+  // Reset line-height so vertical spacing can be consistent
+  line-height: 1;
+}
+
 .page-header__title {
   font-size: $page-header-title-font-size;
   font-weight: $page-header-font-weight;
@@ -19,9 +25,5 @@
 
 .page-header--bordered {
   border-bottom: $page-header-border;
-
-  .page-header__subtitle {
-    // Add spacing between subtitle and border
-    margin-bottom: $page-header-subtitle-spacing;
-  }
+  padding-bottom: $page-header-title-spacing;
 }

--- a/scss/underdog/variables/_page-header.scss
+++ b/scss/underdog/variables/_page-header.scss
@@ -1,6 +1,5 @@
 $page-header-border: 2px solid $border-color;
 $page-header-font-weight: $font-weight-bold;
-$page-header-spacing: $base-spacing-unit * 2;
-$page-header-subtitle-spacing: $base-spacing-unit;
+$page-header-spacing: $base-spacing-unit * 1.5;
 $page-header-title-font-size: 30px !default;
-$page-header-title-spacing: $half-spacing-unit;
+$page-header-title-spacing: $quarter-spacing-unit * 3;


### PR DESCRIPTION
Fixes some spacing issues in `.page-header`.

*Before*

<img width="556" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/17031031/39490eac-4f40-11e6-9790-31013bf83f57.png">

*After*

<img width="525" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/17031028/3678c9e2-4f40-11e6-811b-f59e99550a26.png">

/cc @underdogio/engineering 