### PR TITLE
Increase line-height of page header subtitles

### DIFF
--- a/docs/components/page-header.md
+++ b/docs/components/page-header.md
@@ -20,7 +20,7 @@ Page headers can also have a bottom border and a subtitle.
 <div class="page-header page-header--bordered">
   <h1 class="page-header__title">Candidate application</h1>
   <p class="page-header__subtitle">
-    This is the only information that we need from you. We promise.
+    Drop your email address below to get started.<br />We'll email you brief instructions to complete the process.
   </p>
 </div>
 
@@ -28,7 +28,7 @@ Page headers can also have a bottom border and a subtitle.
 <div class="page-header page-header--bordered">
   <h1 class="page-header__title">Candidate application</h1>
   <p class="page-header__subtitle">
-    This is the only information that we need from you. We promise.
+    Drop your email address below to get started. We'll email you brief instructions to complete the process.
   </p>
 </div>
 ```

--- a/scss/underdog/components/_page-header.scss
+++ b/scss/underdog/components/_page-header.scss
@@ -2,15 +2,11 @@
   margin-bottom: $page-header-spacing;
 }
 
-.page-header__title,
-.page-header__subtitle {
-  // Reset line-height so vertical spacing can be consistent
-  line-height: 1;
-}
-
 .page-header__title {
   font-size: $page-header-title-font-size;
   font-weight: $page-header-font-weight;
+  // Reset line-height so vertical spacing can be consistent
+  line-height: 1;
   margin-bottom: $page-header-title-spacing;
 
   &:only-child {


### PR DESCRIPTION
Updates the line-height of page header subtitles so that separate lines in multiline subtitles won't be so close to each other.

*Before*

<img width="472" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/17065247/d35e5140-500e-11e6-88cc-a1f89eb3e47d.png">

*After*

<img width="476" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/17065250/d6247b5c-500e-11e6-9d75-da3540f15b93.png">

/cc @underdogio/engineering @cmuir 