### PR TITLE
Don't override default link styling in hero

### DIFF
--- a/docs/components/hero.md
+++ b/docs/components/hero.md
@@ -16,11 +16,9 @@ be the first element in a page, and there should never be more than one hero on 
     <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
     <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
     <div class="row">
-      <div class="col-5-large-and-up offset-1-large-and-up push18--bottom">
-        <a class="btn btn--primary btn--large btn--block" href="#hero">Candidates</a>
-      </div>
-      <div class="col-5-large-and-up">
-        <a class="btn btn--primary btn--large btn--block" href="#hero">Companies</a>
+      <div class="col-4-large-and-up offset-4-large-and-up">
+        <a class="btn btn--primary btn--large btn--block push18--bottom" href="#hero">Candidates</a>
+        <a href="#hero">Is your team hiring?</a>
       </div>
     </div>
   </div>
@@ -33,11 +31,9 @@ be the first element in a page, and there should never be more than one hero on 
     <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
     <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
     <div class="row">
-      <div class="col-5-large-and-up offset-1-large-and-up push18--bottom">
-        <a class="btn btn--primary btn--large btn--block" href="#hero">Candidates</a>
-      </div>
-      <div class="col-5-large-and-up">
-        <a class="btn btn--primary btn--large btn--block" href="#hero">Companies</a>
+      <div class="col-4-large-and-up offset-4-large-and-up">
+        <a class="btn btn--primary btn--large btn--block push18--bottom" href="#hero">Candidates</a>
+        <a href="#hero">Is your team hiring?</a>
       </div>
     </div>
   </div>

--- a/scss/underdog/objects/_hero.scss
+++ b/scss/underdog/objects/_hero.scss
@@ -5,17 +5,6 @@
   justify-content: center;
   padding: $hero-padding;
   text-align: center;
-
-  a:not(.btn) {
-    // Make links visible
-    // DEV: By default links have the same color as the hero background
-    color: inherit;
-
-    &:focus,
-    &:hover {
-      color: $link-hover-color;
-    }
-  }
 }
 
 .hero__content {


### PR DESCRIPTION
Since hero's no longer have a colored background, there's no need to change link colors.

*Before*

<img width="432" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/17119902/e1770bd4-5296-11e6-92a6-073df7e39b94.png">

*After*

<img width="334" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/17119900/decb7744-5296-11e6-8cfa-75e49cb6e407.png">


/cc @underdogio/engineering 