### PR TITLE
Allow hero to scale with screen height

### DIFF
--- a/scss/underdog/objects/_hero.scss
+++ b/scss/underdog/objects/_hero.scss
@@ -33,5 +33,6 @@
 }
 
 .hero--large {
+  height: $hero-large-height;
   min-height: $hero-large-min-height;
 }

--- a/scss/underdog/variables/_hero.scss
+++ b/scss/underdog/variables/_hero.scss
@@ -3,7 +3,8 @@ $hero-color: $white;
 $hero-padding: ($base-spacing-unit * 4) $base-spacing-width;
 $hero-max-width: 50rem;
 
-$hero-large-min-height: 90vh;
+$hero-large-height: 80vh;
+$hero-large-min-height: 720px;
 
 $hero-subtitle-color: $subheader-color;
 


### PR DESCRIPTION
Sets the height of `.hero--large` to use a viewport unit so that it can scale to match the height of the screen. It has been been given a `min-height` value to ensure that there is always enough room for the content inside of it.

<img width="1676" alt="large" src="https://cloud.githubusercontent.com/assets/6979137/17184845/5a8ecf78-53fc-11e6-8eb2-b2c8f57bfaef.png">

/cc @underdogio/engineering 