### PR TITLE
Add promo page styles

### DIFF
--- a/docs/layout/promo.md
+++ b/docs/layout/promo.md
@@ -1,0 +1,42 @@
+---
+title: Promo
+category: Layout
+---
+
+Styles for promotional pages, like a landing page.
+
+<div class="promo container text-center">
+  <div class="row">
+    <div class="col-12 col-6-medium-and-up">
+      <h2 class="promo__header">Some of our happy customers</h2>
+      <p class="promo__explanatory">
+        Nobis ratione, aenean nam, laborum magnis! Aut proin consectetur exercitationem, magnis in. Facilisi. Ullam proident.
+      </p>
+    </div>
+    <div class="col-12 col-6-medium-and-up">
+      <h2 class="promo__header">We love you</h2>
+      <p class="promo__explanatory">
+        Provident nunc excepteur ligula morbi vitae mollis blandit, nonummy mollis, iusto pariatur maecenas, enim conubia.
+      </p>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="promo container text-center">
+  <div class="row">
+    <div class="col-12 col-6-medium-and-up">
+      <h2 class="promo__header">Some of our happy customers</h2>
+      <p class="promo__explanatory">
+        Nobis ratione, aenean nam, laborum magnis! Aut proin consectetur exercitationem, magnis in. Facilisi. Ullam proident.
+      </p>
+    </div>
+    <div class="col-12 col-6-medium-and-up">
+      <h2 class="promo__header">We love you</h2>
+      <p class="promo__explanatory">
+        Provident nunc excepteur ligula morbi vitae mollis blandit, nonummy mollis, iusto pariatur maecenas, enim conubia.
+      </p>
+    </div>
+  </div>
+</div>
+```

--- a/scss/underdog/_underdog.scss
+++ b/scss/underdog/_underdog.scss
@@ -28,6 +28,7 @@
 @import 'components/modal';
 @import 'components/nav-list';
 @import 'components/page-header';
+@import 'components/promo';
 @import 'components/section-divider';
 @import 'components/sidebar';
 @import 'components/slab';

--- a/scss/underdog/_variables.scss
+++ b/scss/underdog/_variables.scss
@@ -47,6 +47,7 @@
 @import 'variables/nav-list';
 @import 'variables/opacity';
 @import 'variables/page-header';
+@import 'variables/promo';
 @import 'variables/section-divider';
 @import 'variables/slab';
 @import 'variables/spinner';

--- a/scss/underdog/components/_promo.scss
+++ b/scss/underdog/components/_promo.scss
@@ -1,0 +1,11 @@
+.promo__header {
+  color: $promo-header-color;
+  font-size: $promo-header-font-size;
+  font-weight: $promo-header-font-weight;
+  margin-bottom: $promo-header-margin-bottom;
+}
+
+.promo__explanatory {
+  color: $promo-explanatory-color;
+  font-size: $promo-explanatory-font-size;
+}

--- a/scss/underdog/variables/_promo.scss
+++ b/scss/underdog/variables/_promo.scss
@@ -1,0 +1,6 @@
+$promo-explanatory-color: $light-gray;
+$promo-explanatory-font-size: 19px;
+$promo-header-color: $dark-gray;
+$promo-header-font-size: 24px;
+$promo-header-font-weight: $font-weight-bold;
+$promo-header-margin-bottom: $base-spacing-unit;


### PR DESCRIPTION
Adds a few styles that are meant just for promotional pages (these styles are from [Zeps](https://app.zeplin.io/project.html#pid=5783eecf83b2efb85b3757e7&sid=579678c8bc9c8cbc49af664f)).

<img width="1128" alt="screen shot 2016-07-27 at 2 27 45 pm" src="https://cloud.githubusercontent.com/assets/6979137/17187223/5ec2106e-5406-11e6-8ef9-ac26995a6d1b.png">

/cc @underdogio/engineering 