### PR TITLE
Decrease max width of hero content

### DIFF
--- a/docs/components/hero.md
+++ b/docs/components/hero.md
@@ -10,13 +10,13 @@ be the first element in a page, and there should never be more than one hero on 
 
 ### Default hero
 
-<div class="hero">
+<div class="hero border--top border--bottom">
   <div class="hero__content">
     <img class="hero__image" alt=" " src="/dist/img/assembly_line.svg" />
     <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
     <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
     <div class="row">
-      <div class="col-4-large-and-up offset-4-large-and-up">
+      <div class="col-12 col-6-large-and-up offset-3-large-and-up">
         <a class="btn btn--primary btn--large btn--block push18--bottom" href="#hero">Candidates</a>
         <a href="#hero">Is your team hiring?</a>
       </div>
@@ -31,47 +31,9 @@ be the first element in a page, and there should never be more than one hero on 
     <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
     <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
     <div class="row">
-      <div class="col-4-large-and-up offset-4-large-and-up">
+      <div class="col-12 col-6-large-and-up offset-3-large-and-up">
         <a class="btn btn--primary btn--large btn--block push18--bottom" href="#hero">Candidates</a>
         <a href="#hero">Is your team hiring?</a>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### Large hero
-
-Use the `.hero--large` modifier to get a larger hero that will scale to take up a majority of the viewport height.
-
-<div class="hero hero--large">
-  <div class="hero__content">
-    <img class="hero__image" alt=" " src="/dist/img/assembly_line.svg" />
-    <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
-    <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
-    <div class="row">
-      <div class="col-5-large-and-up offset-1-large-and-up push18--bottom">
-        <a class="btn btn--primary btn--large btn--block" href="#hero">Candidates</a>
-      </div>
-      <div class="col-5-large-and-up">
-        <a class="btn btn--primary btn--large btn--block" href="#hero">Companies</a>
-      </div>
-    </div>
-  </div>
-</div>
-
-```html
-<div class="hero hero--large">
-  <div class="hero__content">
-    <img class="hero__image" alt=" " src="/dist/img/assembly_line.svg" />
-    <h1 class="hero__title">Apply to top technology jobs in 60 seconds</h1>
-    <p class="hero__subtitle">We connect job seekers to awesome companies in New York, San Francisco, and beyond.</p>
-    <div class="row">
-      <div class="col-5-large-and-up offset-1-large-and-up push18--bottom">
-        <a class="btn btn--primary btn--large btn--block" href="#hero">Candidates</a>
-      </div>
-      <div class="col-5-large-and-up">
-        <a class="btn btn--primary btn--large btn--block" href="#hero">Companies</a>
       </div>
     </div>
   </div>

--- a/scss/underdog/objects/_hero.scss
+++ b/scss/underdog/objects/_hero.scss
@@ -11,15 +11,22 @@
   max-width: $hero-max-width;
 }
 
+.hero__title,
+.hero__subtitle {
+  line-height: normal;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: $hero-titles-max-width;
+}
+
 .hero__title {
-  @extend .push30--bottom;
+  @extend .push18--bottom;
   font-size: $hero-title-font-size;
   font-weight: $hero-title-font-weight;
-  line-height: normal;
 }
 
 .hero__image {
-  @extend .push45--bottom;
+  @extend .push30--bottom;
   display: block;
   margin-left: auto;
   margin-right: auto;
@@ -27,12 +34,6 @@
 
 .hero__subtitle {
   @extend .beta;
-  @extend .push45--bottom;
+  @extend .push30--bottom;
   color: $hero-subtitle-color;
-  line-height: normal;
-}
-
-.hero--large {
-  height: $hero-large-height;
-  min-height: $hero-large-min-height;
 }

--- a/scss/underdog/variables/_hero.scss
+++ b/scss/underdog/variables/_hero.scss
@@ -1,12 +1,11 @@
 $hero-bg: $green;
 $hero-color: $white;
-$hero-padding: ($base-spacing-unit * 4) $base-spacing-width;
+$hero-padding: ($base-spacing-unit * 2) $base-spacing-width;
 $hero-max-width: 50rem;
-
-$hero-large-height: 80vh;
-$hero-large-min-height: 720px;
 
 $hero-subtitle-color: $subheader-color;
 
 $hero-title-font-size: $huge-font-size;
 $hero-title-font-weight: $font-weight-light;
+
+$hero-titles-max-width: 475px;


### PR DESCRIPTION
Decrease the max width of `.hero__content` so we can get rid of the ugly `<br />` tags that break things in mobile.

*Before*

<img width="1107" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/17191449/f4cc3eac-5417-11e6-983d-8fe734e731e1.png">

*After (ignore button text being off-center, un-related issue)*

<img width="1106" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/17191454/f896d8e4-5417-11e6-8d4f-32af92adb63a.png">

/cc @underdogio/engineering 