### PR TITLE
Remove margin bottom property from row class

### DIFF
--- a/scss/underdog/objects/_grid.scss
+++ b/scss/underdog/objects/_grid.scss
@@ -47,7 +47,6 @@
 .row {
   // Inherit clearfix properties from `.cf`
   @extend .cf;
-  margin-bottom: 0;
   margin-left: -($gutter-width / 2);
   margin-right: -($gutter-width / 2);
 }


### PR DESCRIPTION
Since the `.row` class is almost always applied to block elements that don't have any bottom margin (div, section, article, etc), there is no point in setting it. Also, setting `margin-bottom` to zero makes it harder to override it by applying another class.

/cc @underdogio/engineering 