### PR TITLE
Match header padding to the grid

### DIFF
--- a/scss/underdog/components/_header.scss
+++ b/scss/underdog/components/_header.scss
@@ -36,13 +36,9 @@
   // Hack for removing extra spacing around <img /> tags
   // SEE: https://css-tricks.com/fighting-the-space-between-inline-block-elements/
   display: flex;
-  // Match grid column gutter
-  margin-left: ($header-padding-horizontal / 2);
 }
 
 .header__nav {
-  // Match grid column gutter
-  margin-right: ($header-padding-horizontal / 2);
   position: relative;
 }
 

--- a/scss/underdog/variables/_header.scss
+++ b/scss/underdog/variables/_header.scss
@@ -2,5 +2,6 @@
 $header-bg: $white;
 $header-color: $whitish-black;
 $header-max-width: 100% !default;
-$header-padding-horizontal: $base-spacing-width;
+// Match grid gutter
+$header-padding-horizontal: $base-spacing-width / 2;
 $header-padding-vertical: $quarter-spacing-unit;


### PR DESCRIPTION
Tweaks header padding so that it can line up with the grid when the header is full width.

*Before*

<img width="593" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/17260280/80a21c18-559d-11e6-999f-837ccbdd66c7.png">

*After*

<img width="593" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/17260290/886cc056-559d-11e6-8bed-fd29c576980b.png">

/cc @underdogio/engineering 
