### PR TITLE
Update link hover color to match regular text color

### DIFF
--- a/scss/underdog/variables/_links.scss
+++ b/scss/underdog/variables/_links.scss
@@ -1,6 +1,6 @@
 // Link coloring
 $link-color: $purple;
-$link-hover-color: $black;
+$link-hover-color: $text-color;
 $link-disabled-color: $light-purple;
 $link-font-weight: $font-weight-bold;
 $nav-link-hover-color: $black;


### PR DESCRIPTION
*Before (#000)*

<img width="90" alt="links hover - before" src="https://cloud.githubusercontent.com/assets/6979137/17260357/deaec45a-559d-11e6-9c43-552da6a4ae15.png">

*After (#444)*

<img width="90" alt="links hover - after" src="https://cloud.githubusercontent.com/assets/6979137/17260356/dc149bac-559d-11e6-92f5-b3b62c3049b6.png">

/cc @underdogio/engineering 