### PR TITLE
Style tables

### DIFF
--- a/docs/base/tables.md
+++ b/docs/base/tables.md
@@ -1,0 +1,85 @@
+---
+title: Tables
+category: Base
+---
+
+Use a table whenever you want to present tabular data.
+
+This should go without saying, but tables should never be used for layout.
+Unless you're writing markup for an email.
+
+<table>
+  <thead>
+    <tr>
+      <th>Location</th>
+      <th>Plan</th>
+      <th>Created</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>New York</td>
+      <td>Free</td>
+      <td>Jul 6, 2016</td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td>Los Angeles (coming soon)</td>
+      <td>Free</td>
+      <td>Aug 3, 2016</td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td>Remote</td>
+      <td>Free</td>
+      <td>Jul 6, 2016</td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td>San Francisco</td>
+      <td>Free</td>
+      <td>Jul 6, 2016</td>
+      <td>Active</td>
+    </tr>
+  </tbody>
+</table>
+
+```html
+<table>
+  <thead>
+    <tr>
+      <th>Location</th>
+      <th>Plan</th>
+      <th>Created</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>New York</td>
+      <td>Free</td>
+      <td>Jul 6, 2016</td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td>Los Angeles (coming soon)</td>
+      <td>Free</td>
+      <td>Aug 3, 2016</td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td>Remote</td>
+      <td>Free</td>
+      <td>Jul 6, 2016</td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td>San Francisco</td>
+      <td>Free</td>
+      <td>Jul 6, 2016</td>
+      <td>Active</td>
+    </tr>
+  </tbody>
+</table>
+```

--- a/scss/underdog/_base.scss
+++ b/scss/underdog/_base.scss
@@ -18,3 +18,4 @@
 @import 'base/forms';
 @import 'base/links';
 @import 'base/lists';
+@import 'base/tables';

--- a/scss/underdog/_variables.scss
+++ b/scss/underdog/_variables.scss
@@ -21,6 +21,7 @@
 @import 'variables/lists';
 @import 'variables/media-queries';
 @import 'variables/push';
+@import 'variables/tables';
 @import 'variables/transitions';
 
 // Object variables

--- a/scss/underdog/base/_tables.scss
+++ b/scss/underdog/base/_tables.scss
@@ -1,0 +1,33 @@
+table {
+  margin: 0 -$table-cell-spacing-horizontal;
+}
+
+th,
+td {
+  padding: $table-cell-spacing-vertical $table-cell-spacing-horizontal;
+}
+
+th {
+  font-weight: $table-heading-font-weight;
+}
+
+@include media-query-medium-and-down {
+  th,
+  td {
+    float: left;
+    width: 50%;
+
+    &:nth-child(2n+1) {
+      clear:left;
+    }
+  }
+
+  tr {
+    border-bottom: 1px solid $table-row-border-color;
+    overflow-x: hidden;
+  }
+
+  th {
+    padding-top: 0;
+  }
+}

--- a/scss/underdog/variables/_tables.scss
+++ b/scss/underdog/variables/_tables.scss
@@ -1,0 +1,6 @@
+@import 'grid';
+
+$table-cell-spacing-horizontal: ($base-spacing-width / 2) !default;
+$table-cell-spacing-vertical: ($half-spacing-unit / 2) !default;
+$table-heading-font-weight: $font-weight-bold !default;
+$table-row-border-color: $border-color !default;


### PR DESCRIPTION
Adds some styles for the good old `table` element.

*Large viewport*

<img width="1125" alt="large" src="https://cloud.githubusercontent.com/assets/6979137/17872240/33ed45d4-688d-11e6-9c50-20d68263cc51.png">

*Medium and down*

<img width="397" alt="medium and down" src="https://cloud.githubusercontent.com/assets/6979137/17872247/361e8b24-688d-11e6-9e7b-6e5c84090c64.png">

/cc @underdogio/engineering 
