### PR TITLE
Override default link styling for case study links

### DIFF
--- a/scss/underdog/components/_case-study-link.scss
+++ b/scss/underdog/components/_case-study-link.scss
@@ -1,8 +1,11 @@
 .case-study-link {
   background: $case-study-link-bg;
   color: $case-study-link-color;
+  text-decoration: none;
 
   &:hover {
+    color: $case-study-link-color;
+
     .case-study-link__title {
       opacity: $opacity-faded;
     }


### PR DESCRIPTION
Removes the underline and color change on hover for the `case-study-link` component.

*Before*

<img width="985" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/17905108/d33c170c-693f-11e6-96cb-d62b6dcc9c11.png">

*After*

<img width="943" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/17905105/d0f82062-693f-11e6-8553-bcc70a329c3d.png">

/cc @underdogio/engineering 