### PR TITLE
Add heading strikethrough component

### DIFF
--- a/docs/components/heading-strikethrough.md
+++ b/docs/components/heading-strikethrough.md
@@ -1,0 +1,18 @@
+---
+title: Heading Strikethrough
+category: Components
+---
+
+<h2 class="heading-strikethrough">
+  <div class="heading-strikethrough__content">
+    Case Studies
+  </div>
+</h2>
+
+```html
+<h2 class="heading-strikethrough">
+  <div class="heading-strikethrough__content">
+    Case Studies
+  </div>
+</h2>
+```

--- a/scss/underdog/_underdog.scss
+++ b/scss/underdog/_underdog.scss
@@ -25,6 +25,7 @@
 @import 'components/dropdown';
 @import 'components/footer';
 @import 'components/header';
+@import 'components/heading-strikethrough';
 @import 'components/list-heading';
 @import 'components/menu-drawer';
 @import 'components/menu-list';

--- a/scss/underdog/_variables.scss
+++ b/scss/underdog/_variables.scss
@@ -43,6 +43,7 @@
 @import 'variables/dropdown';
 @import 'variables/footer';
 @import 'variables/header';
+@import 'variables/heading-strikethrough';
 @import 'variables/list-heading';
 @import 'variables/menu-drawer';
 @import 'variables/menu-list';

--- a/scss/underdog/components/_heading-strikethrough.scss
+++ b/scss/underdog/components/_heading-strikethrough.scss
@@ -1,0 +1,29 @@
+.heading-strikethrough {
+  @include all-caps;
+  font-size: $heading-strikethrough-font-size;
+  font-weight: $heading-strikethrough-font-weight;
+  margin-bottom: $heading-strikethrough-spacing;
+  position: relative;
+
+  &:after {
+    background: $heading-strikethrough-border-color;
+    content: '';
+    display: block;
+    height: 1px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 100%;
+    z-index: 0;
+  }
+}
+
+.heading-strikethrough__content {
+  background: $heading-strikethrough-content-background;
+  color: $heading-strikethrough-color;
+  display: inline-block;
+  padding-right: 1em;
+  position: relative;
+  z-index: 1;
+}

--- a/scss/underdog/variables/_heading-strikethrough.scss
+++ b/scss/underdog/variables/_heading-strikethrough.scss
@@ -1,0 +1,6 @@
+$heading-strikethrough-border-color: $border-color-dark !default;
+$heading-strikethrough-color: $light-gray !default;
+$heading-strikethrough-content-background: $white !default;
+$heading-strikethrough-font-size: 12px !default;
+$heading-strikethrough-font-weight: $font-weight-bold !default;
+$heading-strikethrough-spacing: $half-spacing-unit !default;


### PR DESCRIPTION
Adds this thing:

<img width="1175" alt="screen shot 2016-08-23 at 3 29 23 pm" src="https://cloud.githubusercontent.com/assets/6979137/17906696/68330a90-6946-11e6-9962-80bf18d5837c.png">

/cc @underdogio/engineering 