### PR TITLE
Center carousel content

### DIFF
--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -10,9 +10,15 @@ must be loaded as well.
 
 <div class="carousel">
   <div class="carousel__wrapper">
-    <div class="carousel__slide">Slide One</div>
-    <div class="carousel__slide">Slide Two</div>
-    <div class="carousel__slide">Slide Three</div>
+    <div class="carousel__slide">
+      "Minus fermentum orci vitae erat, interdum cupidatat odio excepteur, quasi blandit praesentium dolores aliquid! Aliquam, dicta wisi elit imperdiet diam iste dictumst molestie laborum, perferendis."
+    </div>
+    <div class="carousel__slide">
+      "Purus cras doloribus posuere nec fringilla reiciendis hic magni, recusandae fusce voluptatem consectetur sociis ipsam elit, facilisis ullamco illo corrupti? Rhoncus laudantium? Aut architecto, phasellus tempore iure massa, suscipit beatae eligendi iste tempus mollitia irure qui. Distinctio exercitation mollis metus explicabo rem. Mollis fusce aenean, taciti egestas etiam porttitor dignissimos."
+    </div>
+    <div class="carousel__slide">
+      "Minus fermentum orci vitae erat, interdum cupidatat odio excepteur, quasi blandit praesentium dolores aliquid! Aliquam, dicta wisi elit imperdiet diam iste dictumst molestie laborum, perferendis."
+    </div>
   </div>
   <div class="carousel__status">
     <span class="carousel__indicator" role="button" aria-label="skip to slide 1" tabindex="0"></span>
@@ -24,9 +30,15 @@ must be loaded as well.
 ```html
 <div class="carousel">
   <div class="carousel__wrapper">
-    <div class="carousel__slide">Slide One</div>
-    <div class="carousel__slide">Slide Two</div>
-    <div class="carousel__slide">Slide Three</div>
+    <div class="carousel__slide">
+      "Minus fermentum orci vitae erat, interdum cupidatat odio excepteur, quasi blandit praesentium dolores aliquid! Aliquam, dicta wisi elit imperdiet diam iste dictumst molestie laborum, perferendis."
+    </div>
+    <div class="carousel__slide">
+      "Purus cras doloribus posuere nec fringilla reiciendis hic magni, recusandae fusce voluptatem consectetur sociis ipsam elit, facilisis ullamco illo corrupti? Rhoncus laudantium? Aut architecto, phasellus tempore iure massa, suscipit beatae eligendi iste tempus mollitia irure qui. Distinctio exercitation mollis metus explicabo rem. Mollis fusce aenean, taciti egestas etiam porttitor dignissimos."
+    </div>
+    <div class="carousel__slide">
+      "Minus fermentum orci vitae erat, interdum cupidatat odio excepteur, quasi blandit praesentium dolores aliquid! Aliquam, dicta wisi elit imperdiet diam iste dictumst molestie laborum, perferendis."
+    </div>
   </div>
   <div class="carousel__status">
     <span class="carousel__indicator" role="button" aria-label="skip to slide 1" tabindex="0"></span>

--- a/scss/underdog/components/_carousel.scss
+++ b/scss/underdog/components/_carousel.scss
@@ -6,6 +6,9 @@
 }
 
 .carousel__wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: center;
   overflow: hidden;
   position: relative;
 }


### PR DESCRIPTION
Carousels stretch to match the height of the current slide, which could look ugly if you have a row of status indicators underneath. This PR attempts to make that situation less ratchet-looking by centering slides within the carousel.

*Example screenshot (mid-slide– mad screenshot taking skills!!)*

<img width="504" alt="screen shot 2016-08-24 at 12 57 05 pm" src="https://cloud.githubusercontent.com/assets/6979137/17939910/92076514-69fa-11e6-92f6-e132ec77470b.png">

/cc @underdogio/engineering 
