### PR TITLE
Set z-index for heading strikethrough

### DIFF
--- a/scss/underdog/components/_heading-strikethrough.scss
+++ b/scss/underdog/components/_heading-strikethrough.scss
@@ -4,6 +4,7 @@
   font-weight: $heading-strikethrough-font-weight;
   margin-bottom: $heading-strikethrough-spacing;
   position: relative;
+  z-index: layer(base);
 
   &:after {
     background: $heading-strikethrough-border-color;


### PR DESCRIPTION
This prevents the header from appearing above other non-statically positioned elements, like say, a fixed nav bar.

/cc @underdogio/engineering 