### PR TITLE
Set display mode of case-study-link to 'block'

### DIFF
--- a/scss/underdog/components/_case-study-link.scss
+++ b/scss/underdog/components/_case-study-link.scss
@@ -1,6 +1,7 @@
 .case-study-link {
   background: $case-study-link-bg;
   color: $case-study-link-color;
+  display: block;
   text-decoration: none;
 
   &:hover {


### PR DESCRIPTION
Fixes the `case-study-link` component for when it collapses to a single column view.

*Screenshot of fix*
<img width="399" alt="screen shot 2016-08-25 at 3 19 53 pm" src="https://cloud.githubusercontent.com/assets/6979137/17982803/8d352dcc-6ad7-11e6-85cb-6e3f7f83b5d3.png">

/cc @underdogio/engineering 