### PR TITLE
Add helpers for setting background colors

### DIFF
--- a/docs/base/001-colors.md
+++ b/docs/base/001-colors.md
@@ -61,6 +61,14 @@ category: Base
   </div>
 </div>
 
+<div class="color-block">
+  <div class="color-block__color" style="background: #F5FAFF"></div>
+  <div class="color-block__label">
+    $light-blue<br />
+    #F5FAFF
+  </div>
+</div>
+
 ## Grayscale
 
 <div class="color-block">

--- a/docs/base/helpers.md
+++ b/docs/base/helpers.md
@@ -3,6 +3,22 @@ title: Helpers
 category: Base
 ---
 
+## Background colors
+
+<div class="color-block">
+  <div class="color-block__color bg--light-blue"></div>
+  <div class="color-block__label">
+    .bg--light-blue<br />
+  </div>
+</div>
+
+<div class="color-block">
+  <div class="color-block__color bg--green"></div>
+  <div class="color-block__label">
+    .bg--green<br />
+  </div>
+</div>
+
 ## Block center
 
 Centers an element that has a display mode set to `block`.

--- a/scss/underdog/generic/_helper.scss
+++ b/scss/underdog/generic/_helper.scss
@@ -9,6 +9,15 @@
   @include center-content;
 }
 
+// Helpers for setting background colors
+.bg--light-blue {
+  background-color: $light-blue;
+}
+
+.bg--green {
+  background-color: $light-green;
+}
+
 // Define custom border helpers
 .border--bottom { border-bottom: $border-width solid $border-color; }
 .border--left { border-left: $border-width solid $border-color; }

--- a/scss/underdog/variables/_colors.scss
+++ b/scss/underdog/variables/_colors.scss
@@ -17,6 +17,7 @@ $orange: #E9A631; // Sunshine
 $green: #72CEAA; // Barf
 $light-green: #ECF6F2; // Playtime
 $blue: #3497FF; // Good boy blue
+$light-blue: #F5FAFF;
 $purple: #59518B; // Pupple
 $light-purple: #908E9E;
 


### PR DESCRIPTION
Adds some new helper classes for setting background colors.

<img width="487" alt="screen shot 2016-09-13 at 1 55 07 pm" src="https://cloud.githubusercontent.com/assets/6979137/18485179/c2f6f9ae-79b9-11e6-96cb-2fcb414b565a.png">

<img width="359" alt="screen shot 2016-09-13 at 1 55 14 pm" src="https://cloud.githubusercontent.com/assets/6979137/18485183/c5f31e44-79b9-11e6-82af-3049f0e5114f.png">

/cc @underdogio/engineering 