### PR TITLE
Set max width for page header component

### DIFF
--- a/scss/underdog/components/_page-header.scss
+++ b/scss/underdog/components/_page-header.scss
@@ -1,5 +1,6 @@
 .page-header {
   margin-bottom: $page-header-spacing;
+  max-width: $page-header-max-width;
 }
 
 .page-header__title {
@@ -16,6 +17,7 @@
 }
 
 .page-header__subtitle {
+  line-height: inherit;
   margin-bottom: 0;
 }
 

--- a/scss/underdog/variables/_page-header.scss
+++ b/scss/underdog/variables/_page-header.scss
@@ -1,5 +1,6 @@
 $page-header-border: 2px solid $border-color;
 $page-header-font-weight: $font-weight-bold;
+$page-header-max-width: 800px;
 $page-header-spacing: $base-spacing-unit;
 $page-header-title-font-size: 30px !default;
 $page-header-title-spacing: $half-spacing-unit;


### PR DESCRIPTION
Sets a max width on the page-header component so that it doesn't run across the full length of larger screens. Also snuck in a tweak to the line height of the subtitle 🙈 

*Before*

<img width="1419" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/18485561/5bb5cfca-79bb-11e6-85b3-d4fd200f4cf8.png">

*After*

<img width="783" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/18485558/5934e5a6-79bb-11e6-8863-e6039ab56b37.png">

/cc @underdogio/engineering 