### PR TITLE
Fix linting error in step-indicator component

### DIFF
--- a/scss/underdog/components/_step-indicator.scss
+++ b/scss/underdog/components/_step-indicator.scss
@@ -24,7 +24,6 @@
     height: $step-indicator-border-width;
     left: 0;
     position: absolute;
-    top: ($step-indicator-orb-size / 2);
     top: calc(($step-indicator-orb-size / 2) - $step-indicator-border-width);
     width: 100%;
     z-index: -1;


### PR DESCRIPTION
Fixes a linting error (duplicate properties) that is causing the Jenkins build to fail on master. Why aren't other builds in PRs failing, even though they have this code in them too? Idk.

/cc @underdogio/engineering 