### PR TITLE
Don't allow text within text-clip to wrap

### DIFF
--- a/docs/base/helpers.md
+++ b/docs/base/helpers.md
@@ -164,7 +164,7 @@ Hides overflowing text.
 Note that this will only work with `block` level elements.
 
 <div class="text-clip border--top border--right border--bottom border--left" style="width: 100px;">
-  <span>chrishasasuperlongname@underdogiscool.com</span>
+  <span>chrishasasuper-longname@underdogiscool.com</span>
 </div>
 
 ```html

--- a/scss/underdog/generic/_helper.scss
+++ b/scss/underdog/generic/_helper.scss
@@ -129,4 +129,5 @@
 .text-clip {
   overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }


### PR DESCRIPTION
Prevents text within `.text-clip` from breaking if it contains a character that could force a line break (like `-`).

*Before*

<img width="161" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/18486662/f302300e-79bf-11e6-8982-e9c00c310433.png">

*After* 

<img width="171" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/18486666/f7f9603c-79bf-11e6-99df-d4213221591d.png">

/cc @underdogio/engineering 