### PR TITLE
Fix pizza spinner

### DIFF
--- a/scss/underdog/components/_spinner.scss
+++ b/scss/underdog/components/_spinner.scss
@@ -9,12 +9,14 @@
     position: relative;
     width: $spinner-size;
 
-    & div {
+    div {
       border-bottom-width: 0;
       border-color: $spinner-color;
+      border-left-width: $spinner-width;
       border-radius: 9999px 9999px 0 0;
+      border-right-width: $spinner-width;
       border-style: solid;
-      border-width: $spinner-width;
+      border-top-width: $spinner-width;
       height: $spinner-size / 2;
       position: absolute;
       width: $spinner-size;
@@ -35,9 +37,11 @@
     height: $spinner-small-size;
     width: $spinner-small-size;
 
-    & div {
+    div {
       border-bottom-width: 0;
-      border-width: $spinner-small-width;
+      border-left-width: $spinner-small-width;
+      border-right-width: $spinner-small-width;
+      border-top-width: $spinner-small-width;
       height: $spinner-small-size / 2;
       width: $spinner-small-size;
 


### PR DESCRIPTION
"Fixes" our spinner that was turned into a pizza / made way better in #273.

The issue was the `border-bottom-width: 0` needed to be placed after `border-width: $spinner-width`, but because this didn't appease our linter by ordering our rules alphabetically, it was placed in the wrong position which caused our spinner to be turned into pizza. To fix this problem all border-width styles had to be set individually. 

*Before*

<img width="78" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/18498479/af7d0648-7a04-11e6-8b73-17387e715c9f.png">

*After*

<img width="75" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/18498472/acb53426-7a04-11e6-8a02-e91781846ae2.png">


/cc @underdogio/engineering 