### PR TITLE
Fix line in step-indicator component 

### DIFF
--- a/scss/underdog/components/_step-indicator.scss
+++ b/scss/underdog/components/_step-indicator.scss
@@ -24,7 +24,7 @@
     height: $step-indicator-border-width;
     left: 0;
     position: absolute;
-    top: calc(($step-indicator-orb-size / 2) - $step-indicator-border-width);
+    top: calc((#{$step-indicator-orb-size} / 2) - #{$step-indicator-border-width});
     width: 100%;
     z-index: -1;
   }


### PR DESCRIPTION
Fixes the line that runs behind the step-indicator component:

*Before*

![screenshot 2016-09-14 11 36 18](https://cloud.githubusercontent.com/assets/6979137/18519043/635e5c1e-7a70-11e6-8064-08009936c6c5.png)

*After*

<img width="286" alt="screen shot 2016-09-14 at 11 41 58 am" src="https://cloud.githubusercontent.com/assets/6979137/18519013/43062aa0-7a70-11e6-8015-2390fcdb7b2b.png">

The issue was that SCSS doesn't automatically interpolate variables when they are passed to CSS functions.

/cc @underdogio/engineering 
