### PR TITLE
Allow button groups to stretch

### DIFF
--- a/docs/components/buttons.md
+++ b/docs/components/buttons.md
@@ -183,43 +183,81 @@ Button groups can be grouped within a `.btn-group`. Button groups can contain an
 type of button.
 
 <div class="btn-group">
-  <a class="btn btn--primary" href="mailto:bark@underdog.io">
-    Email
-  </a>
-  <button class="btn btn--primary btn--small">
-    <span class="icon icon-arrow icon--small">
-    </span>
-  </button>
+  <div class="btn-group__content">
+    <a class="btn btn--primary" href="mailto:bark@underdog.io">
+      Email
+    </a>
+    <button class="btn btn--primary btn--small">
+      <span class="icon icon-arrow icon--small">
+      </span>
+    </button>
+  </div>
 </div>
 
 <div class="btn-group">
-  <button class="btn btn--secondary">
-    A button
-  </button>
-  <button class="btn btn--secondary btn--small">
-    <span class="icon icon-arrow icon--small">
-    </span>
-  </button>
+  <div class="btn-group__content">
+    <button class="btn btn--secondary">
+      A button
+    </button>
+    <button class="btn btn--secondary btn--small">
+      <span class="icon icon-arrow icon--small">
+      </span>
+    </button>
+  </div>
 </div>
 
 ```html
 <div class="btn-group">
-  <a class="btn btn--primary" href="mailto:bark@underdog.io">
-    Email
-  </a>
-  <button class="btn btn--primary btn--small">
-    <span class="icon icon-arrow icon--small">
-    </span>
-  </button>
+  <div class="btn-group__content">
+    <a class="btn btn--primary" href="mailto:bark@underdog.io">
+      Email
+    </a>
+    <button class="btn btn--primary btn--small">
+      <span class="icon icon-arrow icon--small">
+      </span>
+    </button>
+  </div>
 </div>
 
 <div class="btn-group">
-  <button class="btn btn--secondary">
-    A button
-  </button>
-  <button class="btn btn--secondary btn--small">
-    <span class="icon icon-arrow icon--small">
-    </span>
-  </button>
+  <div class="btn-group__content">
+    <button class="btn btn--secondary">
+      A button
+    </button>
+    <button class="btn btn--secondary btn--small">
+      <span class="icon icon-arrow icon--small">
+      </span>
+    </button>
+  </div>
+</div>
+```
+
+You can also use the `.btn--block` class on a `.btn--group`:
+
+<div style="max-width: 100%; width: 200px;">
+  <div class="btn-group btn--block">
+    <div class="btn-group__content">
+      <a class="btn btn--primary" href="mailto:bark@underdog.io">
+        Email
+      </a>
+      <button class="btn btn--primary btn--small btn-group__small">
+        <span class="icon icon-arrow icon--small">
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="btn-group btn--block">
+  <div class="btn-group__content">
+    <a class="btn btn--primary" href="mailto:bark@underdog.io">
+      Email
+    </a>
+    <button class="btn btn--primary btn--small btn-group__small">
+      <span class="icon icon-arrow icon--small">
+      </span>
+    </button>
+  </div>
 </div>
 ```

--- a/scss/underdog/objects/_buttons.scss
+++ b/scss/underdog/objects/_buttons.scss
@@ -165,3 +165,18 @@
     }
   }
 }
+
+// Have buttons take up full width of .btn-group container
+.btn-group__content {
+  display: flex;
+
+  // Allow each button to change width as needed
+  .btn {
+    flex: 1 1 auto;
+  }
+
+  // Helper to prevent a button from stretching
+  .btn-group__small {
+    flex: 0 0 auto;
+  }
+}


### PR DESCRIPTION
Right now if you try to use the `.btn--block` class on a `.btn-group` the button group stretches to fill the width of its container, but the buttons to dot fill out the remaining space of the `.btn-group`:

<img width="293" alt="screen shot 2016-09-20 at 11 42 39 am" src="https://cloud.githubusercontent.com/assets/6979137/18677657/824b8ed8-7f27-11e6-9c19-d213c045958b.png">

This PR fixes that issue by adding a new `.btn-group__content` element that allows buttons to stretch with the magic of flexbox:

<img width="289" alt="screen shot 2016-09-20 at 11 41 53 am" src="https://cloud.githubusercontent.com/assets/6979137/18677677/9707bedc-7f27-11e6-9a83-4a3338e40bcb.png">

Since these new styles are restricted to the new `.btn-group__content` element, this change won't affect any existing button groups that may be out there in production.

/cc @underdogio/engineering 