### PR TITLE
Render tooltips above dropdown menus

### DIFF
--- a/scss/underdog/components/_tooltip.scss
+++ b/scss/underdog/components/_tooltip.scss
@@ -7,6 +7,7 @@
     font-size: $tooltip-font-size;
     letter-spacing: 0;
     text-transform: none;
+    z-index: layer(tooltips);
   }
 
   &:before {

--- a/scss/underdog/variables/_layers.scss
+++ b/scss/underdog/variables/_layers.scss
@@ -1,8 +1,9 @@
 $layer: (
   base: 0,
   header: 1,
-  dropdown-menu: 2,  
-  modals: 3
+  dropdown-menu: 2,
+  tooltips: 3,
+  modals: 4
 );
 
 @function layer($key) {


### PR DESCRIPTION
Allows tooltips to be displayed over open drop down menus.

/cc @underdogio/engineering 