### PR TITLE
Add classes for modifying width of dropdowns

### DIFF
--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -50,3 +50,117 @@ Use to display menu items in a hidden menu.
   </div>
 </div>
 ```
+
+Dropdowns have `display` set to `inline-block` by default. You can have a
+dropdown take up the full width of its container with the
+`.dropdown--block` class:
+
+<div style="margin-bottom: 300px; max-width: 100%; width: 300px">
+  <div class="dropdown dropdown--block">
+    <button class="btn btn--secondary btn--block">
+      <span class="icon__label icon__label--reverse">Menu toggle</span>
+      <span class="icon icon-arrow icon--small"></span>
+    </button>
+    <div class="dropdown__menu">
+      <div class="dropdown__menu-wrapper">
+        <span class="list-heading">chrishasasuperlongname@underdog.io</span>
+        <div class="dropdown__menu-content">
+          <ul class="menu-list">
+            <li class="menu-list__item">
+              <a class="nav-link" href="/settings/">Settings</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/support/">Support</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/logout/">Log out</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="dropdown dropdown--block">
+  <button class="btn btn--secondary btn--block">
+    <span class="icon__label icon__label--reverse">Menu toggle</span>
+    <span class="icon icon-arrow icon--small"></span>
+  </button>
+<div class="dropdown__menu">
+  <div class="dropdown__menu-wrapper">
+    <span class="list-heading">chrishasasuperlongname@underdog.io</span>
+    <div class="dropdown__menu-content">
+      <ul class="menu-list">
+        <li class="menu-list__item">
+          <a class="nav-link" href="/settings/">Settings</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="/support/">Support</a>
+        </li>
+        <li class="menu-list__item">
+          <a class="nav-link" href="/logout/">Log out</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+```
+
+If you are want to fit really wide content within a dropdown menu, you can use
+the `.dropdown__menu--auto-width` class:
+
+<div style="margin-bottom: 300px; max-width: 100%; width: 350px">
+  <div class="dropdown dropdown--block">
+    <button class="btn btn--secondary btn--block">
+      <span class="icon__label icon__label--reverse">Menu toggle</span>
+      <span class="icon icon-arrow icon--small"></span>
+    </button>
+    <div class="dropdown__menu dropdown__menu--auto-width">
+      <div class="dropdown__menu-wrapper">
+        <span class="list-heading">chrishasasuperlongname@underdog.io</span>
+        <div class="dropdown__menu-content">
+          <ul class="menu-list">
+            <li class="menu-list__item">
+              <a class="btn btn--block btn--secondary" href="/settings/">This is a super wide button</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/support/">Support</a>
+            </li>
+            <li class="menu-list__item">
+              <a class="nav-link" href="/logout/">Log out</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="dropdown dropdown--block">
+  <button class="btn btn--secondary btn--block">
+    <span class="icon__label icon__label--reverse">Menu toggle</span>
+    <span class="icon icon-arrow icon--small"></span>
+  </button>
+  <div class="dropdown__menu dropdown__menu--auto-width">
+    <div class="dropdown__menu-wrapper">
+      <span class="list-heading">chrishasasuperlongname@underdog.io</span>
+      <div class="dropdown__menu-content">
+        <ul class="menu-list">
+          <li class="menu-list__item">
+            <a class="btn btn--block btn--secondary" href="/settings/">This is a super wide button</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/support/">Support</a>
+          </li>
+          <li class="menu-list__item">
+            <a class="nav-link" href="/logout/">Log out</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+```

--- a/scss/underdog/components/_dropdown.scss
+++ b/scss/underdog/components/_dropdown.scss
@@ -7,6 +7,11 @@
   font-weight: $font-weight-normal;
 }
 
+.dropdown--block {
+  display: block;
+  width: 100%;
+}
+
 .dropdown__menu {
   line-height: $base-line-height;
   margin-top: $dropdown-menu-triangle-size;
@@ -42,6 +47,10 @@
     top: 11.4px;
     z-index: 1;
   }
+}
+
+.dropdown__menu--auto-width {
+  width: auto;
 }
 
 .dropdown__menu-wrapper {


### PR DESCRIPTION
Adds some classes that allow the width of `dropdown` and `dropdown__menu` to be modified, so we can do stuff like this:

<img width="473" alt="screen shot 2016-09-20 at 12 21 31 pm" src="https://cloud.githubusercontent.com/assets/6979137/18679378/65362168-7f2d-11e6-9e08-a7cffa506285.png">

/cc @underdogio/engineering 