### PR TITLE
Remove min-height from textarea

### DIFF
--- a/scss/underdog/base/_forms.scss
+++ b/scss/underdog/base/_forms.scss
@@ -53,7 +53,6 @@ select {
 }
 
 textarea {
-  min-height: 10rem;
   resize: vertical;
 }
 


### PR DESCRIPTION
Removes the `min-height` style rule for `<textarea />`s so that we can keep the textarea small for when we are auto re-sizing its height on user input.

/cc @underdogio/engineering @cmuir 